### PR TITLE
fix(wallet-android): accept mixed DID aliases

### DIFF
--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
@@ -25,8 +25,10 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
         completionBlock: (VCLResult<Boolean>) -> Unit
     ) {
         deepLink.did?.let { deepLinkDid ->
-            if (didDocument.id == presentationRequest.iss && didDocument.id == deepLinkDid ||
-                didDocument.alsoKnownAs.contains(presentationRequest.iss) && didDocument.alsoKnownAs.contains(deepLinkDid)) {
+            if (
+                isDidBoundToDidDocument(presentationRequest.iss, didDocument) &&
+                isDidBoundToDidDocument(deepLinkDid, didDocument)
+            ) {
                 completionBlock(VCLResult.Success(true))
             } else {
                 onError(
@@ -35,8 +37,14 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
                     completionBlock = completionBlock
                 )
             }
-        }
+        } ?: onError(
+            errorMessage = "DID not found in deep link: ${deepLink.value}",
+            completionBlock = completionBlock,
+        )
     }
+
+    private fun isDidBoundToDidDocument(did: String, didDocument: VCLDidDocument): Boolean =
+        didDocument.id == did || didDocument.alsoKnownAs.contains(did)
 
     private fun onError(
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,

--- a/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
@@ -1,15 +1,19 @@
 package io.velocitycareerlabs.verifiers
 
+import io.velocitycareerlabs.api.entities.VCLDeepLink
+import io.velocitycareerlabs.api.entities.VCLDidDocument
 import io.velocitycareerlabs.api.entities.error.VCLErrorCode
 import io.velocitycareerlabs.api.entities.handleResult
-import io.velocitycareerlabs.impl.data.repositories.ResolveDidDocumentRepositoryImpl
 import io.velocitycareerlabs.impl.data.verifiers.PresentationRequestByDeepLinkVerifierImpl
 import io.velocitycareerlabs.impl.domain.verifiers.PresentationRequestByDeepLinkVerifier
-import io.velocitycareerlabs.infrastructure.network.NetworkServiceSuccess
 import io.velocitycareerlabs.infrastructure.resources.valid.DeepLinkMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.DidDocumentMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.PresentationRequestMocks
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Test
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 class PresentationRequestByDeepLinkVerifierTest {
     private lateinit var subject: PresentationRequestByDeepLinkVerifier
@@ -34,6 +38,56 @@ class PresentationRequestByDeepLinkVerifierTest {
     }
 
     @Test
+    fun testVerifyPresentationRequestSuccessWithDidDocumentIdInDeepLink() {
+        subject = PresentationRequestByDeepLinkVerifierImpl()
+        val deepLinkWithDidDocumentId = deepLinkWithInspectorDid(DidDocumentMocks.DidDocumentMock.id)
+
+        subject.verifyPresentationRequest(
+            presentationRequest,
+            deepLinkWithDidDocumentId,
+            DidDocumentMocks.DidDocumentMock
+        ) {
+            it.handleResult({ isVerified ->
+                assert(isVerified)
+            }, { error ->
+                assert(false) { "${error.toJsonObject()}" }
+            })
+        }
+    }
+
+    @Test
+    fun testVerifyPresentationRequestSuccessWithDidDocumentIdInPresentationRequest() {
+        subject = PresentationRequestByDeepLinkVerifierImpl()
+
+        val originalDidDocumentId = DidDocumentMocks.DidDocumentMock.id
+        val didDocumentPayload = JSONObject(DidDocumentMocks.DidDocumentMock.payload.toString())
+        didDocumentPayload.put(VCLDidDocument.KeyId, presentationRequest.iss)
+
+        val alsoKnownAs = didDocumentPayload.optJSONArray(VCLDidDocument.KeyAlsoKnownAs) ?: JSONArray()
+        val alreadyContainsOriginalDidDocumentId = (0 until alsoKnownAs.length())
+            .any { alsoKnownAs.optString(it) == originalDidDocumentId }
+        if (!alreadyContainsOriginalDidDocumentId) {
+            alsoKnownAs.put(originalDidDocumentId)
+        }
+        didDocumentPayload.put(VCLDidDocument.KeyAlsoKnownAs, alsoKnownAs)
+
+        val didDocumentWithPresentationRequestIss = VCLDidDocument(didDocumentPayload)
+        val deepLinkWithDidDocumentAlias = deepLinkWithInspectorDid(originalDidDocumentId)
+
+        subject.verifyPresentationRequest(
+            presentationRequest,
+            deepLinkWithDidDocumentAlias,
+            didDocumentWithPresentationRequestIss
+        ) {
+            it.handleResult({ isVerified ->
+                assert(isVerified)
+            }, { error ->
+                assert(false) { "${error.toJsonObject()}" }
+            })
+        }
+    }
+
+    @Test
     fun testVerifyPresentationRequestError() {
         subject = PresentationRequestByDeepLinkVerifierImpl()
 
@@ -48,5 +102,10 @@ class PresentationRequestByDeepLinkVerifierTest {
                 assert(error.errorCode == VCLErrorCode.MismatchedPresentationRequestInspectorDid.value)
             })
         }
+    }
+
+    private fun deepLinkWithInspectorDid(inspectorDid: String): VCLDeepLink {
+        val encodedInspectorDid = URLEncoder.encode(inspectorDid, StandardCharsets.UTF_8.toString())
+        return VCLDeepLink(value = "velocity-network://inspect?inspectorDid=$encodedInspectorDid")
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
@@ -33,9 +33,9 @@ class PresentationRequestByDeepLinkVerifierTest {
             DidDocumentMocks.DidDocumentMock
         ) {
             it.handleResult({ isVerified ->
-                assert(isVerified)
+                assertTrue(isVerified)
             }, { error ->
-                assert(false) { "${error.toJsonObject()}" }
+                fail("${error.toJsonObject()}")
             })
         }
     }
@@ -51,9 +51,9 @@ class PresentationRequestByDeepLinkVerifierTest {
             DidDocumentMocks.DidDocumentMock
         ) {
             it.handleResult({ isVerified ->
-                assert(isVerified)
+                assertTrue(isVerified)
             }, { error ->
-                assert(false) { "${error.toJsonObject()}" }
+                fail("${error.toJsonObject()}")
             })
         }
     }
@@ -83,9 +83,9 @@ class PresentationRequestByDeepLinkVerifierTest {
             didDocumentWithPresentationRequestIss
         ) {
             it.handleResult({ isVerified ->
-                assert(isVerified)
+                assertTrue(isVerified)
             }, { error ->
-                assert(false) { "${error.toJsonObject()}" }
+                fail("${error.toJsonObject()}")
             })
         }
     }
@@ -100,9 +100,9 @@ class PresentationRequestByDeepLinkVerifierTest {
             DidDocumentMocks.DidDocumentWithWrongDidMock
         ) {
             it.handleResult({
-                assert(false) { "${VCLErrorCode.MismatchedPresentationRequestInspectorDid.value} error code is expected" }
+                fail("${VCLErrorCode.MismatchedPresentationRequestInspectorDid.value} error code is expected")
             }, { error ->
-                assert(error.errorCode == VCLErrorCode.MismatchedPresentationRequestInspectorDid.value)
+                assertEquals(VCLErrorCode.MismatchedPresentationRequestInspectorDid.value, error.errorCode)
             })
         }
     }

--- a/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
@@ -11,6 +11,9 @@ import io.velocitycareerlabs.infrastructure.resources.valid.DidDocumentMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.PresentationRequestMocks
 import org.json.JSONArray
 import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -100,6 +103,24 @@ class PresentationRequestByDeepLinkVerifierTest {
                 assert(false) { "${VCLErrorCode.MismatchedPresentationRequestInspectorDid.value} error code is expected" }
             }, { error ->
                 assert(error.errorCode == VCLErrorCode.MismatchedPresentationRequestInspectorDid.value)
+            })
+        }
+    }
+
+    @Test
+    fun testVerifyPresentationRequestErrorWhenDeepLinkDidMissing() {
+        subject = PresentationRequestByDeepLinkVerifierImpl()
+
+        subject.verifyPresentationRequest(
+            presentationRequest,
+            VCLDeepLink(value = "velocity-network://inspect"),
+            DidDocumentMocks.DidDocumentMock
+        ) {
+            it.handleResult({
+                fail("${VCLErrorCode.SdkError.value} error code is expected")
+            }, { error ->
+                assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+                assertTrue(error.message?.contains("DID not found in deep link") == true)
             })
         }
     }


### PR DESCRIPTION
## Summary
- update `PresentationRequestByDeepLinkVerifierImpl` to validate each DID against `didDocument.id` OR `didDocument.alsoKnownAs`
- keep mismatch behavior for real mismatches and return explicit error when deep-link DID is missing
- add tests for both mixed valid combinations in `PresentationRequestByDeepLinkVerifierTest`

## Why
Valid presentation requests were rejected when one DID matched `id` and the other matched `alsoKnownAs`.

## Validation
- `./gradlew :VCL:testDebugUnitTest`