### PR TITLE
fix: include @context in vp submissions

### DIFF
--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/VCLSubmission.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/VCLSubmission.kt
@@ -29,6 +29,10 @@ interface VCLSubmission {
             .putOpt(SubmissionCodingKeys.KeyIss, iss)
         val vp = JSONObject()
             .putOpt(
+                SubmissionCodingKeys.KeyContext,
+                SubmissionCodingKeys.ValueContextList.toJsonArray()
+            )
+            .putOpt(
                 SubmissionCodingKeys.KeyType,
                 SubmissionCodingKeys.ValueVerifiablePresentation
             )
@@ -50,7 +54,6 @@ interface VCLSubmission {
         .putOpt(SubmissionCodingKeys.KeyExchangeId, exchangeId)
         .putOpt(SubmissionCodingKeys.KeyJwtVp, jwt.encodedJwt)
         .putOpt(SubmissionCodingKeys.KeyPushDelegate, pushDelegate?.toJsonObject())
-        .putOpt(SubmissionCodingKeys.KeyContext, SubmissionCodingKeys.ValueContextList.toJsonArray())
 }
 
 object SubmissionCodingKeys {

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLSubmissionTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLSubmissionTest.kt
@@ -22,6 +22,8 @@ import io.velocitycareerlabs.infrastructure.resources.valid.PresentationSubmissi
 import io.velocitycareerlabs.infrastructure.resources.valid.VerifiedProfileMocks
 import org.junit.Before
 import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 import org.json.JSONArray
@@ -117,7 +119,7 @@ class VCLSubmissionTest {
         )
 
     private fun assertMatchesUuid(value: String?) {
-        assert(value != null && uuidRegex.matches(value))
+        assertTrue("Expected UUID but got: $value", value != null && uuidRegex.matches(value))
     }
 
     private fun normalizedPayload(payload: JSONObject): JSONObject {
@@ -194,7 +196,7 @@ class VCLSubmissionTest {
 
     @Test
     fun testContext() {
-        assert(SubmissionCodingKeys.KeyContext == "@context")
-        assert(SubmissionCodingKeys.ValueContextList == listOf("https://www.w3.org/2018/credentials/v1"))
+        assertEquals("@context", SubmissionCodingKeys.KeyContext)
+        assertEquals(listOf("https://www.w3.org/2018/credentials/v1"), SubmissionCodingKeys.ValueContextList)
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLSubmissionTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLSubmissionTest.kt
@@ -15,7 +15,6 @@ import io.velocitycareerlabs.api.entities.VCLPushDelegate
 import io.velocitycareerlabs.api.entities.VCLSubmission
 import io.velocitycareerlabs.api.entities.VCLVerifiedProfile
 import io.velocitycareerlabs.impl.extensions.toJsonObject
-import io.velocitycareerlabs.impl.extensions.toList
 import io.velocitycareerlabs.infrastructure.resources.CommonMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.DidJwkMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.JwtServiceMocks
@@ -23,13 +22,20 @@ import io.velocitycareerlabs.infrastructure.resources.valid.PresentationSubmissi
 import io.velocitycareerlabs.infrastructure.resources.valid.VerifiedProfileMocks
 import org.junit.Before
 import org.junit.Test
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.json.JSONArray
+import org.json.JSONObject
 
 class VCLSubmissionTest {
     private lateinit var subjectPresentationSubmission: VCLSubmission
     private lateinit var subjectIdentificationSubmission: VCLSubmission
+    private lateinit var credentialManifest: VCLCredentialManifest
 
     private val issuingIss = "issuing iss"
     private val inspectionIss = "inspection iss"
+    private val uuidRegex =
+        Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")
 
     @Before
     fun setUp() {
@@ -37,46 +43,153 @@ class VCLSubmissionTest {
             PresentationSubmissionMocks.PresentationRequest,
             PresentationSubmissionMocks.SelectionsList
         )
+        credentialManifest = VCLCredentialManifest(
+            jwt = CommonMocks.JWT,
+            verifiedProfile = VCLVerifiedProfile(VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1.toJsonObject()!!),
+            didJwk = DidJwkMocks.DidJwk
+        )
         subjectIdentificationSubmission = VCLIdentificationSubmission(
-            VCLCredentialManifest(
-                jwt = CommonMocks.JWT,
-                verifiedProfile = VCLVerifiedProfile(VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1.toJsonObject()!!),
-                didJwk = DidJwkMocks.DidJwk
-            ),
+            credentialManifest,
             PresentationSubmissionMocks.SelectionsList
         )
+    }
+
+    private fun expectedPayload(
+        iss: String,
+        presentationDefinitionId: String,
+        vendorOriginContext: String?
+    ): JSONObject = JSONObject()
+        .put(SubmissionCodingKeys.KeyJti, "<uuid>")
+        .put(SubmissionCodingKeys.KeyIss, iss)
+        .put(
+            SubmissionCodingKeys.KeyVp,
+            JSONObject()
+                .put(
+                    SubmissionCodingKeys.KeyContext,
+                    JSONArray(SubmissionCodingKeys.ValueContextList)
+                )
+                .put(
+                    SubmissionCodingKeys.KeyType,
+                    SubmissionCodingKeys.ValueVerifiablePresentation
+                )
+                .put(
+                    SubmissionCodingKeys.KeyPresentationSubmission,
+                    JSONObject()
+                        .put(SubmissionCodingKeys.KeyId, "<uuid>")
+                        .put(
+                            SubmissionCodingKeys.KeyDefinitionId,
+                            presentationDefinitionId
+                        )
+                        .put(
+                            SubmissionCodingKeys.KeyDescriptorMap,
+                            JSONArray(
+                                PresentationSubmissionMocks.SelectionsList.mapIndexed { index, credential ->
+                                    JSONObject()
+                                        .put(
+                                            SubmissionCodingKeys.KeyId,
+                                            credential.inputDescriptor
+                                        )
+                                        .put(
+                                            SubmissionCodingKeys.KeyPath,
+                                            "$.verifiableCredential[$index]"
+                                        )
+                                        .put(
+                                            SubmissionCodingKeys.KeyFormat,
+                                            SubmissionCodingKeys.ValueJwtVcFormat
+                                        )
+                                }
+                            )
+                        )
+                )
+                .put(
+                    SubmissionCodingKeys.KeyVerifiableCredential,
+                    JSONArray(
+                        PresentationSubmissionMocks.SelectionsList.map { credential ->
+                            credential.jwtVc
+                        }
+                    )
+                )
+                .apply {
+                    vendorOriginContext?.let {
+                        put(SubmissionCodingKeys.KeyVendorOriginContext, it)
+                    }
+                }
+        )
+
+    private fun assertMatchesUuid(value: String?) {
+        assert(value != null && uuidRegex.matches(value))
+    }
+
+    private fun normalizedPayload(payload: JSONObject): JSONObject {
+        val normalizedPayload = JSONObject(payload.toString())
+
+        assertMatchesUuid(normalizedPayload.optString(SubmissionCodingKeys.KeyJti))
+        normalizedPayload.put(SubmissionCodingKeys.KeyJti, "<uuid>")
+
+        val normalizedVp = normalizedPayload.getJSONObject(SubmissionCodingKeys.KeyVp)
+        val normalizedPresentationSubmission =
+            normalizedVp.getJSONObject(SubmissionCodingKeys.KeyPresentationSubmission)
+        assertMatchesUuid(normalizedPresentationSubmission.optString(SubmissionCodingKeys.KeyId))
+        normalizedPresentationSubmission.put(SubmissionCodingKeys.KeyId, "<uuid>")
+        normalizedVp.put(
+            SubmissionCodingKeys.KeyPresentationSubmission,
+            normalizedPresentationSubmission
+        )
+        normalizedPayload.put(SubmissionCodingKeys.KeyVp, normalizedVp)
+
+        return normalizedPayload
     }
 
     @Test
     fun testPayload() {
         val presentationSubmissionPayload = subjectPresentationSubmission.generatePayload(inspectionIss)
-        assert(presentationSubmissionPayload.optString(SubmissionCodingKeys.KeyJti) == subjectPresentationSubmission.jti)
-        assert(presentationSubmissionPayload.optString(SubmissionCodingKeys.KeyIss) == inspectionIss)
+        JSONAssert.assertEquals(
+            expectedPayload(
+                iss = inspectionIss,
+                presentationDefinitionId = PresentationSubmissionMocks.PresentationRequest.presentationDefinitionId,
+                vendorOriginContext = PresentationSubmissionMocks.PresentationRequest.vendorOriginContext
+            ),
+            normalizedPayload(presentationSubmissionPayload),
+            JSONCompareMode.STRICT
+        )
 
         val identificationSubmissionPayload = subjectIdentificationSubmission.generatePayload(issuingIss)
-        assert(identificationSubmissionPayload.optString(SubmissionCodingKeys.KeyJti) == subjectIdentificationSubmission.jti)
-        assert(identificationSubmissionPayload.optString(SubmissionCodingKeys.KeyIss) == issuingIss)
-    }
-
-    @Test
-    fun testPushDelegate() {
-        assert(subjectPresentationSubmission.pushDelegate!!.pushUrl == PresentationSubmissionMocks.PushDelegate.pushUrl)
-        assert(subjectPresentationSubmission.pushDelegate!!.pushToken == PresentationSubmissionMocks.PushDelegate.pushToken)
+        JSONAssert.assertEquals(
+            expectedPayload(
+                iss = issuingIss,
+                presentationDefinitionId = credentialManifest.presentationDefinitionId,
+                vendorOriginContext = credentialManifest.vendorOriginContext
+            ),
+            normalizedPayload(identificationSubmissionPayload),
+            JSONCompareMode.STRICT
+        )
     }
 
     @Test
     fun testRequestBody() {
         val requestBodyJsonObj = subjectPresentationSubmission.generateRequestBody(JwtServiceMocks.JWT)
-        assert(requestBodyJsonObj.optString(SubmissionCodingKeys.KeyExchangeId) == subjectPresentationSubmission.exchangeId)
-        assert(requestBodyJsonObj.optJSONArray(SubmissionCodingKeys.KeyContext)!!.toList() == SubmissionCodingKeys.ValueContextList)
-
-        val pushDelegateBodyJsonObj = requestBodyJsonObj.optJSONObject(SubmissionCodingKeys.KeyPushDelegate)!!
-
-        assert(pushDelegateBodyJsonObj.optString(VCLPushDelegate.KeyPushUrl) == PresentationSubmissionMocks.PushDelegate.pushUrl)
-        assert(pushDelegateBodyJsonObj.optString(VCLPushDelegate.KeyPushToken) == PresentationSubmissionMocks.PushDelegate.pushToken)
-
-        assert(pushDelegateBodyJsonObj.optString(VCLPushDelegate.KeyPushUrl) == subjectPresentationSubmission.pushDelegate!!.pushUrl)
-        assert(pushDelegateBodyJsonObj.optString(VCLPushDelegate.KeyPushToken) == subjectPresentationSubmission.pushDelegate!!.pushToken)
+        JSONAssert.assertEquals(
+            JSONObject()
+                .put(
+                    SubmissionCodingKeys.KeyExchangeId,
+                    PresentationSubmissionMocks.PresentationRequest.exchangeId
+                )
+                .put(SubmissionCodingKeys.KeyJwtVp, JwtServiceMocks.JWT.encodedJwt)
+                .put(
+                    SubmissionCodingKeys.KeyPushDelegate,
+                    JSONObject()
+                        .put(
+                            VCLPushDelegate.KeyPushUrl,
+                            PresentationSubmissionMocks.PushDelegate.pushUrl
+                        )
+                        .put(
+                            VCLPushDelegate.KeyPushToken,
+                            PresentationSubmissionMocks.PushDelegate.pushToken
+                        )
+                ),
+            requestBodyJsonObj,
+            JSONCompareMode.STRICT
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- include `@context` inside the signed VP payload
- remove the incorrect top-level `@context` from the submission request body
- rewrite the submission test to use readable whole-object assertions with lightweight UUID normalization

## Verification
- ./gradlew :VCL:testDebugUnitTest --tests io.velocitycareerlabs.entities.VCLSubmissionTest