### PR TITLE
[codex] Clarify VCLError contract

### DIFF
--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -19,7 +19,7 @@ data class VCLError(
     val statusCode: Int? = null,
 ) : Error(message) {
     @Deprecated(
-        message = "Use named arguments for human-readable text, or VCLError.fromPayload(...) for payload parsing.",
+        message = "Use named arguments for human-readable text, or VCLError.fromPayloadJson(...) for payload parsing.",
     )
     constructor(
         payload: String?,
@@ -56,27 +56,11 @@ data class VCLError(
         }
 
     companion object CodingKeys {
-        fun fromPayload(
-            payload: String?,
-            errorCode: String? = null,
-        ): VCLError {
-            val payloadJson = payload?.toJsonObject()
-            return if (payloadJson != null) {
-                fromPayload(payload, payloadJson, errorCode)
-            } else {
-                VCLError(
-                    payload = payload,
-                    errorCode = errorCode ?: VCLErrorCode.SdkError.value,
-                )
-            }
-        }
-
-        internal fun fromPayload(
-            payload: String?,
+        fun fromPayloadJson(
             payloadJson: JSONObject,
             errorCode: String? = null,
         ) = VCLError(
-            payload = payload,
+            payload = payloadJson.toString(),
             error = payloadJson.optNullableString(KeyError),
             errorCode = errorCode ?: payloadJson.optNullableString(KeyErrorCode)
                 ?: VCLErrorCode.SdkError.value,

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -20,21 +20,11 @@ data class VCLError(
 ) : Error(message) {
     @Deprecated(
         message = "Use named arguments for human-readable text, or VCLError.fromPayload(...) for payload parsing.",
-        replaceWith = ReplaceWith("VCLError.fromPayload(payload, errorCode)")
     )
     constructor(
         payload: String?,
         errorCode: String? = null,
-    ) : this(
-        payload = payload,
-        error = payload?.toJsonObject()?.optString(KeyError),
-        errorCode =
-            errorCode ?: payload?.toJsonObject()?.optString(KeyErrorCode)
-                ?: VCLErrorCode.SdkError.value,
-        requestId = payload?.toJsonObject()?.optString(KeyRequestId),
-        message = payload?.toJsonObject()?.optString(KeyMessage),
-        statusCode = payload?.toJsonObject()?.optInt(KeyStatusCode),
-    )
+    ) : this(parsePayload(payload, payload?.toJsonObject(), errorCode))
 
     constructor(
         exception: Exception,
@@ -60,18 +50,44 @@ data class VCLError(
         fun fromPayload(
             payload: String?,
             errorCode: String? = null,
-        ): VCLError {
-            val payloadJson = payload?.toJsonObject()
-            return VCLError(
+        ) = VCLError(parsePayload(payload, payload?.toJsonObject(), errorCode))
+
+        internal fun fromPayload(
+            payload: String?,
+            payloadJson: JSONObject,
+            errorCode: String? = null,
+        ) = VCLError(parsePayload(payload, payloadJson, errorCode))
+
+        private fun parsePayload(
+            payload: String?,
+            payloadJson: JSONObject?,
+            errorCode: String?,
+        ): ParsedPayload {
+            return ParsedPayload(
                 payload = payload,
-                error = payloadJson?.optString(KeyError),
-                errorCode = errorCode ?: payloadJson?.optString(KeyErrorCode)
+                error = payloadJson.optNullableString(KeyError),
+                errorCode = errorCode ?: payloadJson.optNullableString(KeyErrorCode)
                     ?: VCLErrorCode.SdkError.value,
-                requestId = payloadJson?.optString(KeyRequestId),
-                message = payloadJson?.optString(KeyMessage),
-                statusCode = payloadJson?.optInt(KeyStatusCode),
+                requestId = payloadJson.optNullableString(KeyRequestId),
+                message = payloadJson.optNullableString(KeyMessage),
+                statusCode = payloadJson.optNullableInt(KeyStatusCode),
             )
         }
+
+        private fun JSONObject?.optNullableString(key: String): String? =
+            takeIf { it?.has(key) == true && !it.isNull(key) }?.optString(key)
+
+        private fun JSONObject?.optNullableInt(key: String): Int? =
+            takeIf { it?.has(key) == true && !it.isNull(key) }?.optInt(key)
+
+        private data class ParsedPayload(
+            val payload: String?,
+            val error: String?,
+            val errorCode: String,
+            val requestId: String?,
+            val message: String?,
+            val statusCode: Int?,
+        )
 
         const val KeyPayload = "payload"
         const val KeyError = "error"
@@ -80,4 +96,13 @@ data class VCLError(
         const val KeyMessage = "message"
         const val KeyStatusCode = "statusCode"
     }
+
+    private constructor(parsedPayload: ParsedPayload) : this(
+        payload = parsedPayload.payload,
+        error = parsedPayload.error,
+        errorCode = parsedPayload.errorCode,
+        requestId = parsedPayload.requestId,
+        message = parsedPayload.message,
+        statusCode = parsedPayload.statusCode,
+    )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -24,7 +24,16 @@ data class VCLError(
     constructor(
         payload: String?,
         errorCode: String? = null,
-    ) : this(parsePayload(payload, payload?.toJsonObject(), errorCode))
+    ) : this(
+        payload = payload,
+        error = payload?.toJsonObject()?.optString(KeyError),
+        errorCode =
+            errorCode ?: payload?.toJsonObject()?.optString(KeyErrorCode)
+                ?: VCLErrorCode.SdkError.value,
+        requestId = payload?.toJsonObject()?.optString(KeyRequestId),
+        message = payload?.toJsonObject()?.optString(KeyMessage),
+        statusCode = payload?.toJsonObject()?.optInt(KeyStatusCode),
+    )
 
     constructor(
         exception: Exception,
@@ -50,44 +59,37 @@ data class VCLError(
         fun fromPayload(
             payload: String?,
             errorCode: String? = null,
-        ) = VCLError(parsePayload(payload, payload?.toJsonObject(), errorCode))
+        ): VCLError {
+            val payloadJson = payload?.toJsonObject()
+            return if (payloadJson != null) {
+                fromPayload(payload, payloadJson, errorCode)
+            } else {
+                VCLError(
+                    payload = payload,
+                    errorCode = errorCode ?: VCLErrorCode.SdkError.value,
+                )
+            }
+        }
 
         internal fun fromPayload(
             payload: String?,
             payloadJson: JSONObject,
             errorCode: String? = null,
-        ) = VCLError(parsePayload(payload, payloadJson, errorCode))
-
-        private fun parsePayload(
-            payload: String?,
-            payloadJson: JSONObject?,
-            errorCode: String?,
-        ): ParsedPayload {
-            return ParsedPayload(
-                payload = payload,
-                error = payloadJson.optNullableString(KeyError),
-                errorCode = errorCode ?: payloadJson.optNullableString(KeyErrorCode)
-                    ?: VCLErrorCode.SdkError.value,
-                requestId = payloadJson.optNullableString(KeyRequestId),
-                message = payloadJson.optNullableString(KeyMessage),
-                statusCode = payloadJson.optNullableInt(KeyStatusCode),
-            )
-        }
+        ) = VCLError(
+            payload = payload,
+            error = payloadJson.optNullableString(KeyError),
+            errorCode = errorCode ?: payloadJson.optNullableString(KeyErrorCode)
+                ?: VCLErrorCode.SdkError.value,
+            requestId = payloadJson.optNullableString(KeyRequestId),
+            message = payloadJson.optNullableString(KeyMessage),
+            statusCode = payloadJson.optNullableInt(KeyStatusCode),
+        )
 
         private fun JSONObject?.optNullableString(key: String): String? =
             takeIf { it?.has(key) == true && !it.isNull(key) }?.optString(key)
 
         private fun JSONObject?.optNullableInt(key: String): Int? =
             takeIf { it?.has(key) == true && !it.isNull(key) }?.optInt(key)
-
-        private data class ParsedPayload(
-            val payload: String?,
-            val error: String?,
-            val errorCode: String,
-            val requestId: String?,
-            val message: String?,
-            val statusCode: Int?,
-        )
 
         const val KeyPayload = "payload"
         const val KeyError = "error"
@@ -96,13 +98,4 @@ data class VCLError(
         const val KeyMessage = "message"
         const val KeyStatusCode = "statusCode"
     }
-
-    private constructor(parsedPayload: ParsedPayload) : this(
-        payload = parsedPayload.payload,
-        error = parsedPayload.error,
-        errorCode = parsedPayload.errorCode,
-        requestId = parsedPayload.requestId,
-        message = parsedPayload.message,
-        statusCode = parsedPayload.statusCode,
-    )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -18,6 +18,10 @@ data class VCLError(
     override val message: String? = null,
     val statusCode: Int? = null,
 ) : Error(message) {
+    @Deprecated(
+        message = "Use named arguments for human-readable text, or VCLError.fromPayload(...) for payload parsing.",
+        replaceWith = ReplaceWith("VCLError.fromPayload(payload, errorCode)")
+    )
     constructor(
         payload: String?,
         errorCode: String? = null,
@@ -53,6 +57,22 @@ data class VCLError(
         }
 
     companion object CodingKeys {
+        fun fromPayload(
+            payload: String?,
+            errorCode: String? = null,
+        ): VCLError {
+            val payloadJson = payload?.toJsonObject()
+            return VCLError(
+                payload = payload,
+                error = payloadJson?.optString(KeyError),
+                errorCode = errorCode ?: payloadJson?.optString(KeyErrorCode)
+                    ?: VCLErrorCode.SdkError.value,
+                requestId = payloadJson?.optString(KeyRequestId),
+                message = payloadJson?.optString(KeyMessage),
+                statusCode = payloadJson?.optInt(KeyStatusCode),
+            )
+        }
+
         const val KeyPayload = "payload"
         const val KeyError = "error"
         const val KeyErrorCode = "errorCode"

--- a/VCL/src/main/java/io/velocitycareerlabs/api/keys/VCLKeyService.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/keys/VCLKeyService.kt
@@ -28,7 +28,7 @@ interface VCLKeyService {
         signatureAlgorithm: VCLSignatureAlgorithm,
         completionBlock: (VCLResult<ECKey>) -> Unit
     ) {
-        completionBlock(VCLResult.Failure(VCLError(payload = "implemented for local crypto services only")))
+        completionBlock(VCLResult.Failure(VCLError(message = "implemented for local crypto services only")))
     }
     /**
      * implemented for local crypto services only
@@ -37,7 +37,7 @@ interface VCLKeyService {
         keyId: String,
         completionBlock: (VCLResult<ECKey>) -> Unit
     ) {
-        completionBlock(VCLResult.Failure(VCLError(payload = "implemented for local crypto services only")))
+        completionBlock(VCLResult.Failure(VCLError(message = "implemented for local crypto services only")))
     }
     /**
      * implemented for local crypto services only
@@ -46,6 +46,6 @@ interface VCLKeyService {
         ecKey: ECKey,
         completionBlock: (VCLResult<ECKey>) -> Unit
     ) {
-        completionBlock(VCLResult.Failure(VCLError(payload = "implemented for local crypto services only")))
+        completionBlock(VCLResult.Failure(VCLError(message = "implemented for local crypto services only")))
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/VCLImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/VCLImpl.kt
@@ -203,7 +203,7 @@ internal class VCLImpl: VCL {
                                 )
                             }
                         } ?: run {
-                            errorHandler(VCLError("Failed to get credential type schemas"))
+                            errorHandler(VCLError(message = "Failed to get credential type schemas"))
                         }
                     }
                 },
@@ -256,7 +256,7 @@ internal class VCLImpl: VCL {
                 }
             )
         } ?: run {
-            VCLError("did was not found in $presentationRequestDescriptor").let {
+            VCLError(message = "did was not found in $presentationRequestDescriptor").let {
                 logError("getPresentationRequest::verifiedProfile", it)
                 errorHandler(it)
             }
@@ -347,7 +347,7 @@ internal class VCLImpl: VCL {
                 }
             )
         } ?: run {
-            VCLError("did was not found in $credentialManifestDescriptor").let {
+            VCLError(message = "did was not found in $credentialManifestDescriptor").let {
                 logError("getCredentialManifest::verifiedProfile", it)
                 errorHandler(it)
             }
@@ -477,7 +477,7 @@ internal class VCLImpl: VCL {
                 )
             }
         } ?: run {
-            val error = VCLError("No countries for getCredentialTypesUIFormSchema")
+            val error = VCLError(message = "No countries for getCredentialTypesUIFormSchema")
             logError("getCredentialTypesUIFormSchema", error)
             errorHandler(error)
         }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -73,18 +73,13 @@ internal class NetworkServiceImpl: NetworkService {
             } else {
                 val errorMessageStream = connection.errorStream ?: connection.inputStream
                 val errorPayload = errorMessageStream.convertToString()
-                val errorPayloadJson = errorPayload.toJsonObject()
                 completionBlock(
                     VCLResult.Failure(
-                        if (errorPayloadJson != null) {
-                            VCLError.fromPayloadJson(errorPayloadJson)
-                        } else {
-                            VCLError(
-                                payload = errorPayload,
-                                message = errorPayload,
-                                statusCode = connection.responseCode
-                            )
-                        }
+                        createError(
+                            payload = errorPayload,
+                            contentType = connection.contentType,
+                            statusCode = connection.responseCode
+                        )
                     )
                 )
             }
@@ -169,4 +164,27 @@ internal class NetworkServiceImpl: NetworkService {
         VCLLog.d(TAG, "Response:\nstatus code: " + response.code)
         VCLLog.d(TAG, response.payload)
     }
+
+    private fun createError(
+        payload: String,
+        contentType: String?,
+        statusCode: Int,
+    ): VCLError {
+        if (isJsonContentType(contentType)) {
+            payload.toJsonObject()?.let { payloadJson ->
+                return VCLError.fromPayloadJson(payloadJson)
+            }
+        }
+
+        return VCLError(
+            payload = payload,
+            message = payload,
+            statusCode = statusCode
+        )
+    }
+
+    private fun isJsonContentType(contentType: String?): Boolean =
+        contentType?.let {
+            it.contains(Request.ContentTypeApplicationJson) || it.contains("+json")
+        } == true
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -185,6 +185,7 @@ internal class NetworkServiceImpl: NetworkService {
 
     private fun isJsonContentType(contentType: String?): Boolean =
         contentType?.let {
-            it.contains(Request.ContentTypeApplicationJson) || it.contains("+json")
+            it.contains(Request.ContentTypeApplicationJson, ignoreCase = true) ||
+                it.contains("+json", ignoreCase = true)
         } == true
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -21,7 +21,9 @@ import java.net.URL
 import java.net.UnknownHostException
 import javax.net.ssl.HttpsURLConnection
 
-internal class NetworkServiceImpl: NetworkService {
+internal class NetworkServiceImpl(
+    private val connectionFactory: ((Request) -> HttpURLConnection)? = null,
+) : NetworkService {
     private val TAG = NetworkServiceImpl::class.simpleName
 
     override fun sendRequest(
@@ -133,11 +135,13 @@ internal class NetworkServiceImpl: NetworkService {
      * Returns new connection. referred to by given url.
      */
     private fun createConnection(request: Request): HttpURLConnection {
-        val connection = if (request.endpoint.startsWith("https")) {
-            URL(request.endpoint).openConnection() as HttpsURLConnection
-        } else {
-            URL(request.endpoint).openConnection() as HttpURLConnection
-        }
+        val connection =
+            connectionFactory?.invoke(request)
+                ?: if (request.endpoint.startsWith("https")) {
+                    URL(request.endpoint).openConnection() as HttpsURLConnection
+                } else {
+                    URL(request.endpoint).openConnection() as HttpURLConnection
+                }
         connection.connectTimeout = request.connectTimeOut
         connection.readTimeout = request.readTimeOut
         connection.requestMethod = request.method.value

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -77,7 +77,7 @@ internal class NetworkServiceImpl: NetworkService {
                 completionBlock(
                     VCLResult.Failure(
                         if (errorPayloadJson != null) {
-                            VCLError.fromPayload(errorPayload, errorPayloadJson)
+                            VCLError.fromPayloadJson(errorPayloadJson)
                         } else {
                             VCLError(
                                 payload = errorPayload,

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -73,23 +73,17 @@ internal class NetworkServiceImpl: NetworkService {
             } else {
                 val errorMessageStream = connection.errorStream ?: connection.inputStream
                 val errorPayload = errorMessageStream.convertToString()
+                val errorPayloadJson = errorPayload.toJsonObject()
                 completionBlock(
                     VCLResult.Failure(
-                        if (errorPayload.toJsonObject() != null) {
-                            VCLError.fromPayload(errorPayload)
+                        if (errorPayloadJson != null) {
+                            VCLError.fromPayload(errorPayload, errorPayloadJson)
                         } else {
                             VCLError(
+                                payload = errorPayload,
                                 message = errorPayload,
                                 statusCode = connection.responseCode
-                            ).let { errorObject ->
-                                VCLError(
-                                    payload = errorObject.toJsonObject().toString(),
-                                    errorCode = errorObject.errorCode,
-                                    requestId = errorObject.requestId,
-                                    message = errorObject.message,
-                                    statusCode = errorObject.statusCode
-                                )
-                            }
+                            )
                         }
                     )
                 )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -13,6 +13,7 @@ import io.velocitycareerlabs.api.entities.error.VCLStatusCode
 import io.velocitycareerlabs.api.entities.VCLResult
 import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
 import io.velocitycareerlabs.impl.extensions.convertToString
+import io.velocitycareerlabs.impl.extensions.toJsonObject
 import io.velocitycareerlabs.impl.utils.VCLLog
 import java.io.*
 import java.net.HttpURLConnection
@@ -71,9 +72,25 @@ internal class NetworkServiceImpl: NetworkService {
                 completionBlock(VCLResult.Success(response))
             } else {
                 val errorMessageStream = connection.errorStream ?: connection.inputStream
+                val errorPayload = errorMessageStream.convertToString()
                 completionBlock(
                     VCLResult.Failure(
-                        VCLError(payload = errorMessageStream.convertToString())
+                        if (errorPayload.toJsonObject() != null) {
+                            VCLError.fromPayload(errorPayload)
+                        } else {
+                            VCLError(
+                                message = errorPayload,
+                                statusCode = connection.responseCode
+                            ).let { errorObject ->
+                                VCLError(
+                                    payload = errorObject.toJsonObject().toString(),
+                                    errorCode = errorObject.errorCode,
+                                    requestId = errorObject.requestId,
+                                    message = errorObject.message,
+                                    statusCode = errorObject.statusCode
+                                )
+                            }
+                        }
                     )
                 )
             }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/infrastructure/network/NetworkServiceImpl.kt
@@ -172,7 +172,9 @@ internal class NetworkServiceImpl: NetworkService {
     ): VCLError {
         if (isJsonContentType(contentType)) {
             payload.toJsonObject()?.let { payloadJson ->
-                return VCLError.fromPayloadJson(payloadJson)
+                val payloadError = VCLError.fromPayloadJson(payloadJson)
+                return payloadError.takeIf { it.statusCode != null }
+                    ?: payloadError.copy(statusCode = statusCode)
             }
         }
 

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/AuthTokenRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/AuthTokenRepositoryImpl.kt
@@ -50,7 +50,7 @@ internal class AuthTokenRepositoryImpl(
                             } ?: run {
                                 completionBlock(
                                     VCLResult.Failure(
-                                        VCLError("Failed to parse: auth token response")
+                                        VCLError(message = "Failed to parse: auth token response")
                                     )
                                 )
                             }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
@@ -46,7 +46,7 @@ internal class CredentialManifestRepositoryImpl(
                 }
             )
         } ?: run {
-            completionBlock(VCLResult.Failure(VCLError("credentialManifestDescriptor.endpoint = null")))
+            completionBlock(VCLResult.Failure(VCLError(message = "credentialManifestDescriptor.endpoint = null")))
         }
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/FinalizeOffersRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/FinalizeOffersRepositoryImpl.kt
@@ -48,7 +48,7 @@ internal class FinalizeOffersRepositoryImpl(
                             } ?: run {
                                 completionBlock(
                                     VCLResult.Failure(
-                                        VCLError("Failed to parse: ${finalizedOffersResponse.payload}")
+                                        VCLError(message = "Failed to parse: ${finalizedOffersResponse.payload}")
                                     )
                                 )
                             }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
@@ -45,7 +45,7 @@ internal class PresentationRequestRepositoryImpl(
                 }
             )
         } ?: run {
-            completionBlock(VCLResult.Failure(VCLError("presentationRequestDescriptor.endpoint = null")))
+            completionBlock(VCLResult.Failure(VCLError(message = "presentationRequestDescriptor.endpoint = null")))
         }
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
@@ -61,7 +61,7 @@ internal class CredentialManifestUseCaseImpl(
                                             )
                                         } ?: run {
                                         onError(
-                                            VCLError("public jwk not found for kid: ${credentialManifest.jwt.kid}"),
+                                            VCLError(message = "public jwk not found for kid: ${credentialManifest.jwt.kid}"),
                                             completionBlock
                                         )
                                     }
@@ -155,7 +155,7 @@ internal class CredentialManifestUseCaseImpl(
             }
         } else {
             onError(
-                VCLError("Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}"),
+                VCLError(message = "Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}"),
                 completionBlock
             )
         }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
@@ -58,7 +58,7 @@ internal class PresentationRequestUseCaseImpl(
                                         )
                                     } ?: run {
                                         onError(
-                                            VCLError("public jwk not found for kid: ${presentationRequest.jwt.kid}"),
+                                            VCLError(message = "public jwk not found for kid: ${presentationRequest.jwt.kid}"),
                                             completionBlock
                                         )
                                     }
@@ -122,7 +122,7 @@ internal class PresentationRequestUseCaseImpl(
             }
         else
             onError(
-                VCLError("Failed  to verify: ${presentationRequest.jwt.payload}"),
+                VCLError(message = "Failed  to verify: ${presentationRequest.jwt.payload}"),
                 completionBlock
             )
     }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
@@ -122,7 +122,7 @@ internal class PresentationRequestUseCaseImpl(
             }
         else
             onError(
-                VCLError(message = "Failed  to verify: ${presentationRequest.jwt.payload}"),
+                VCLError(message = "Failed to verify: ${presentationRequest.jwt.payload}"),
                 completionBlock
             )
     }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/directissuerverification/CredentialIssuerVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/directissuerverification/CredentialIssuerVerifierImpl.kt
@@ -158,7 +158,11 @@ internal class CredentialIssuerVerifierImpl(
                             onError(
                                 VCLError(
                                     payload = error.payload,
-                                    errorCode = VCLErrorCode.InvalidCredentialSubjectContext.value
+                                    error = error.error,
+                                    errorCode = VCLErrorCode.InvalidCredentialSubjectContext.value,
+                                    requestId = error.requestId,
+                                    message = error.message,
+                                    statusCode = error.statusCode
                                 ),
                                 completionBlock
                             )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/directissuerverification/repositories/CredentialSubjectContextRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/directissuerverification/repositories/CredentialSubjectContextRepositoryImpl.kt
@@ -37,7 +37,7 @@ internal class CredentialSubjectContextRepositoryImpl(
                     ldContextResponse.payload.toJsonObject()?.toMap()?.let {
                         completionBlock(VCLResult.Success(it))
                     } ?: run {
-                        val error = VCLError("Unexpected LD-Context payload for $credentialSubjectContextEndpoint")
+                        val error = VCLError(message = "Unexpected LD-Context payload for $credentialSubjectContextEndpoint")
                         completionBlock(VCLResult.Failure(error))
                     }
                 }, { error ->

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/jwt/remote/VCLJwtSignServiceRemoteImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/jwt/remote/VCLJwtSignServiceRemoteImpl.kt
@@ -52,7 +52,7 @@ internal class VCLJwtSignServiceRemoteImpl(
                         } ?: run {
                             completionBlock(
                                 VCLResult.Failure(
-                                VCLError(message = "Failed to parse data from $jwtSignServiceUrl")
+                                    VCLError(message = "Failed to parse data from $jwtSignServiceUrl")
                                 )
                             )
                         }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/jwt/remote/VCLJwtSignServiceRemoteImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/jwt/remote/VCLJwtSignServiceRemoteImpl.kt
@@ -52,7 +52,7 @@ internal class VCLJwtSignServiceRemoteImpl(
                         } ?: run {
                             completionBlock(
                                 VCLResult.Failure(
-                                VCLError(payload = "Failed to parse data from $jwtSignServiceUrl")
+                                VCLError(message = "Failed to parse data from $jwtSignServiceUrl")
                                 )
                             )
                         }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/keys/VCLKeyServiceRemoteImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/keys/VCLKeyServiceRemoteImpl.kt
@@ -61,7 +61,7 @@ internal class VCLKeyServiceRemoteImpl(
                         } ?: run {
                             completionBlock(
                                 VCLResult.Failure(
-                                    VCLError("Failed to create did:jwk from the provided URL: ${keyServiceUrls.createDidKeyServiceUrl}")
+                                    VCLError(message = "Failed to create did:jwk from the provided URL: ${keyServiceUrls.createDidKeyServiceUrl}")
                                 )
                             )
                         }

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -10,6 +10,8 @@ package io.velocitycareerlabs.entities
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
 import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VCLErrorTest {
@@ -27,7 +29,7 @@ class VCLErrorTest {
             statusCode = ErrorMocks.StatusCode
         )
 
-        assert(error == expectedError)
+        assertEquals(expectedError, error)
     }
 
     @Test
@@ -47,7 +49,7 @@ class VCLErrorTest {
             statusCode = ErrorMocks.StatusCode
         )
 
-        assert(error == expectedError)
+        assertEquals(expectedError, error)
     }
 
     @Test
@@ -63,7 +65,7 @@ class VCLErrorTest {
             .put(VCLError.KeyMessage, ErrorMocks.Message)
             .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
 
-        assert(errorJsonObject.similar(expectedJsonObject))
+        assertTrue(errorJsonObject.similar(expectedJsonObject))
     }
 
     @Test
@@ -83,6 +85,6 @@ class VCLErrorTest {
             .put(VCLError.KeyMessage, ErrorMocks.Message)
             .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
 
-        assert(errorJsonObject.similar(expectedJsonObject))
+        assertTrue(errorJsonObject.similar(expectedJsonObject))
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -17,13 +17,16 @@ class VCLErrorTest {
     @Test
     fun testErrorFromPayload() {
         val error = VCLError.fromPayloadJson(JSONObject(ErrorMocks.Payload))
+        val expectedError = VCLError(
+            payload = JSONObject(ErrorMocks.Payload).toString(),
+            error = ErrorMocks.Error,
+            errorCode = ErrorMocks.ErrorCode,
+            requestId = ErrorMocks.RequestId,
+            message = ErrorMocks.Message,
+            statusCode = ErrorMocks.StatusCode
+        )
 
-        assert(JSONObject(error.payload ?: "").toString() == JSONObject(ErrorMocks.Payload).toString())
-        assert(error.error == ErrorMocks.Error)
-        assert(error.errorCode == ErrorMocks.ErrorCode)
-        assert(error.requestId == ErrorMocks.RequestId)
-        assert(error.message == ErrorMocks.Message)
-        assert(error.statusCode == ErrorMocks.StatusCode)
+        assert(error == expectedError)
     }
 
     @Test
@@ -35,26 +38,30 @@ class VCLErrorTest {
             message = ErrorMocks.Message,
             statusCode = ErrorMocks.StatusCode
         )
+        val expectedError = VCLError(
+            error = ErrorMocks.Error,
+            errorCode = ErrorMocks.ErrorCode,
+            requestId = ErrorMocks.RequestId,
+            message = ErrorMocks.Message,
+            statusCode = ErrorMocks.StatusCode
+        )
 
-        assert(error.payload == null)
-        assert(error.error == ErrorMocks.Error)
-        assert(error.errorCode == ErrorMocks.ErrorCode)
-        assert(error.requestId == ErrorMocks.RequestId)
-        assert(error.message == ErrorMocks.Message)
-        assert(error.statusCode == ErrorMocks.StatusCode)
+        assert(error == expectedError)
     }
 
     @Test
     fun testErrorToJsonFromPayload() {
         val error = VCLError.fromPayloadJson(JSONObject(ErrorMocks.Payload))
         val errorJsonObject = error.toJsonObject()
+        val expectedJsonObject = JSONObject()
+            .put(VCLError.KeyPayload, JSONObject(ErrorMocks.Payload).toString())
+            .put(VCLError.KeyError, ErrorMocks.Error)
+            .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
+            .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
+            .put(VCLError.KeyMessage, ErrorMocks.Message)
+            .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
 
-        assert(JSONObject(errorJsonObject.optString(VCLError.KeyPayload)).toString() == JSONObject(ErrorMocks.Payload).toString())
-        assert(errorJsonObject.optString(VCLError.KeyError) == ErrorMocks.Error)
-        assert(errorJsonObject.optString(VCLError.KeyErrorCode) == ErrorMocks.ErrorCode)
-        assert(errorJsonObject.optString(VCLError.KeyRequestId) == ErrorMocks.RequestId)
-        assert(errorJsonObject.optString(VCLError.KeyMessage) == ErrorMocks.Message)
-        assert(errorJsonObject.optInt(VCLError.KeyStatusCode) == ErrorMocks.StatusCode)
+        assert(errorJsonObject.similar(expectedJsonObject))
     }
 
     @Test
@@ -67,12 +74,13 @@ class VCLErrorTest {
             statusCode = ErrorMocks.StatusCode
         )
         val errorJsonObject = error.toJsonObject()
+        val expectedJsonObject = JSONObject()
+            .put(VCLError.KeyError, ErrorMocks.Error)
+            .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
+            .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
+            .put(VCLError.KeyMessage, ErrorMocks.Message)
+            .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
 
-        assert(errorJsonObject.optString(VCLError.KeyPayload) == "")
-        assert(errorJsonObject.optString(VCLError.KeyError) == ErrorMocks.Error)
-        assert(errorJsonObject.optString(VCLError.KeyErrorCode) == ErrorMocks.ErrorCode)
-        assert(errorJsonObject.optString(VCLError.KeyRequestId) == ErrorMocks.RequestId)
-        assert(errorJsonObject.optString(VCLError.KeyMessage) == ErrorMocks.Message)
-        assert(errorJsonObject.optInt(VCLError.KeyStatusCode) == ErrorMocks.StatusCode)
+        assert(errorJsonObject.similar(expectedJsonObject))
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -9,15 +9,16 @@ package io.velocitycareerlabs.entities
 
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
+import org.json.JSONObject
 import org.junit.Test
 
 class VCLErrorTest {
 
     @Test
     fun testErrorFromPayload() {
-        val error = VCLError.fromPayload(ErrorMocks.Payload)
+        val error = VCLError.fromPayloadJson(JSONObject(ErrorMocks.Payload))
 
-        assert(error.payload == ErrorMocks.Payload)
+        assert(JSONObject(error.payload ?: "").toString() == JSONObject(ErrorMocks.Payload).toString())
         assert(error.error == ErrorMocks.Error)
         assert(error.errorCode == ErrorMocks.ErrorCode)
         assert(error.requestId == ErrorMocks.RequestId)
@@ -45,10 +46,10 @@ class VCLErrorTest {
 
     @Test
     fun testErrorToJsonFromPayload() {
-        val error = VCLError.fromPayload(ErrorMocks.Payload)
+        val error = VCLError.fromPayloadJson(JSONObject(ErrorMocks.Payload))
         val errorJsonObject = error.toJsonObject()
 
-        assert(errorJsonObject.optString(VCLError.KeyPayload) == ErrorMocks.Payload)
+        assert(JSONObject(errorJsonObject.optString(VCLError.KeyPayload)).toString() == JSONObject(ErrorMocks.Payload).toString())
         assert(errorJsonObject.optString(VCLError.KeyError) == ErrorMocks.Error)
         assert(errorJsonObject.optString(VCLError.KeyErrorCode) == ErrorMocks.ErrorCode)
         assert(errorJsonObject.optString(VCLError.KeyRequestId) == ErrorMocks.RequestId)

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -15,7 +15,7 @@ class VCLErrorTest {
 
     @Test
     fun testErrorFromPayload() {
-        val error = VCLError(ErrorMocks.Payload)
+        val error = VCLError.fromPayload(ErrorMocks.Payload)
 
         assert(error.payload == ErrorMocks.Payload)
         assert(error.error == ErrorMocks.Error)
@@ -45,7 +45,7 @@ class VCLErrorTest {
 
     @Test
     fun testErrorToJsonFromPayload() {
-        val error = VCLError(ErrorMocks.Payload)
+        val error = VCLError.fromPayload(ErrorMocks.Payload)
         val errorJsonObject = error.toJsonObject()
 
         assert(errorJsonObject.optString(VCLError.KeyPayload) == ErrorMocks.Payload)

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -16,9 +16,10 @@ class VCLErrorTest {
 
     @Test
     fun testErrorFromPayload() {
-        val error = VCLError.fromPayloadJson(JSONObject(ErrorMocks.Payload))
+        val payloadJson = JSONObject(ErrorMocks.Payload)
+        val error = VCLError.fromPayloadJson(payloadJson)
         val expectedError = VCLError(
-            payload = JSONObject(ErrorMocks.Payload).toString(),
+            payload = payloadJson.toString(),
             error = ErrorMocks.Error,
             errorCode = ErrorMocks.ErrorCode,
             requestId = ErrorMocks.RequestId,
@@ -51,10 +52,11 @@ class VCLErrorTest {
 
     @Test
     fun testErrorToJsonFromPayload() {
-        val error = VCLError.fromPayloadJson(JSONObject(ErrorMocks.Payload))
+        val payloadJson = JSONObject(ErrorMocks.Payload)
+        val error = VCLError.fromPayloadJson(payloadJson)
         val errorJsonObject = error.toJsonObject()
         val expectedJsonObject = JSONObject()
-            .put(VCLError.KeyPayload, JSONObject(ErrorMocks.Payload).toString())
+            .put(VCLError.KeyPayload, payloadJson.toString())
             .put(VCLError.KeyError, ErrorMocks.Error)
             .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
             .put(VCLError.KeyRequestId, ErrorMocks.RequestId)

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceFailure.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceFailure.kt
@@ -26,6 +26,6 @@ internal class NetworkServiceFailure(
         useCaches: Boolean,
         completionBlock: (VCLResult<Response>) -> Unit
     ) {
-        completionBlock(VCLResult.Failure(VCLError(errorMessage)))
+        completionBlock(VCLResult.Failure(VCLError.fromPayload(errorMessage)))
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceFailure.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceFailure.kt
@@ -26,6 +26,6 @@ internal class NetworkServiceFailure(
         useCaches: Boolean,
         completionBlock: (VCLResult<Response>) -> Unit
     ) {
-        completionBlock(VCLResult.Failure(VCLError.fromPayload(errorMessage)))
+        completionBlock(VCLResult.Failure(VCLError(message = errorMessage)))
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
@@ -15,26 +15,13 @@ import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.net.URLConnection
-import java.net.URLStreamHandler
-import java.net.URLStreamHandlerFactory
-import java.util.concurrent.atomic.AtomicBoolean
 
 internal class NetworkServiceImplTest {
-    private lateinit var subject: NetworkServiceImpl
-
-    @Before
-    fun setUp() {
-        installMockProtocolFactoryIfNeeded()
-        subject = NetworkServiceImpl()
-    }
-
     @Test
     fun testJsonErrorBodyUsesPayloadJsonFactory() {
         val payloadJson = JSONObject(ErrorMocks.Payload)
@@ -153,18 +140,19 @@ internal class NetworkServiceImplTest {
         contentType: String?,
         responseCode: Int,
     ): VCLError {
-        nextConnectionFactory = { url ->
+        val subject =
+            NetworkServiceImpl(connectionFactory = { request ->
             FakeHttpURLConnection(
-                url = url,
+                url = URL(request.endpoint),
                 responseCodeValue = responseCode,
                 contentTypeValue = contentType,
                 errorPayload = payload
             )
-        }
+            })
 
         var result: VCLResult<io.velocitycareerlabs.impl.data.infrastructure.network.Response>? = null
         subject.sendRequest(
-            endpoint = "mockhttp://example.com/error",
+            endpoint = "http://example.com/error",
             body = null,
             contentType = Request.ContentTypeApplicationJson,
             method = Request.HttpMethod.GET,
@@ -199,31 +187,5 @@ internal class NetworkServiceImplTest {
 
         override fun getInputStream(): InputStream =
             ByteArrayInputStream((errorPayload ?: "").toByteArray())
-    }
-
-    private companion object {
-        private const val MockProtocol = "mockhttp"
-        private val isFactoryInstalled = AtomicBoolean(false)
-
-        @Volatile
-        private var nextConnectionFactory: ((URL) -> HttpURLConnection)? = null
-
-        private fun installMockProtocolFactoryIfNeeded() {
-            if (isFactoryInstalled.compareAndSet(false, true)) {
-                URL.setURLStreamHandlerFactory(
-                    URLStreamHandlerFactory { protocol ->
-                        if (protocol == MockProtocol) {
-                            object : URLStreamHandler() {
-                                override fun openConnection(url: URL): URLConnection =
-                                    nextConnectionFactory?.invoke(url)
-                                        ?: error("No connection factory configured for $url")
-                            }
-                        } else {
-                            null
-                        }
-                    }
-                )
-            }
-        }
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
@@ -1,6 +1,4 @@
 /**
- * Created by OpenAI Codex on 13/04/2026.
- *
  * Copyright 2022 Velocity Career Labs inc.
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,6 +13,7 @@ import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.InputStream
@@ -32,9 +31,10 @@ internal class NetworkServiceImplTest {
             responseCode = 400
         )
 
+        assertPayloadJsonEquals(payloadJson, error)
         assertEquals(
             VCLError(
-                payload = payloadJson.toString(),
+                payload = error.payload,
                 error = ErrorMocks.Error,
                 errorCode = ErrorMocks.ErrorCode,
                 requestId = ErrorMocks.RequestId,
@@ -55,9 +55,10 @@ internal class NetworkServiceImplTest {
             responseCode = 400
         )
 
+        assertPayloadJsonEquals(payloadJson, error)
         assertEquals(
             VCLError(
-                payload = payloadJson.toString(),
+                payload = error.payload,
                 error = ErrorMocks.Error,
                 errorCode = ErrorMocks.ErrorCode,
                 requestId = ErrorMocks.RequestId,
@@ -80,9 +81,10 @@ internal class NetworkServiceImplTest {
             responseCode = 422
         )
 
+        assertPayloadJsonEquals(payloadJson, error)
         assertEquals(
             VCLError(
-                payload = payloadJson.toString(),
+                payload = error.payload,
                 error = ErrorMocks.Error,
                 errorCode = ErrorMocks.ErrorCode,
                 requestId = ErrorMocks.RequestId,
@@ -164,6 +166,13 @@ internal class NetworkServiceImplTest {
 
         return (result as? VCLResult.Failure)?.error
             ?: error("Expected NetworkServiceImpl to return VCLResult.Failure")
+    }
+
+    private fun assertPayloadJsonEquals(
+        expectedPayloadJson: JSONObject,
+        error: VCLError,
+    ) {
+        assertTrue(JSONObject(error.payload!!).similar(expectedPayloadJson))
     }
 
     private class FakeHttpURLConnection(

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
@@ -14,6 +14,7 @@ import io.velocitycareerlabs.impl.data.infrastructure.network.NetworkServiceImpl
 import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
 import org.json.JSONObject
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -24,7 +25,6 @@ import java.net.URLConnection
 import java.net.URLStreamHandler
 import java.net.URLStreamHandlerFactory
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.test.assertEquals
 
 internal class NetworkServiceImplTest {
     private lateinit var subject: NetworkServiceImpl

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
@@ -82,6 +82,31 @@ internal class NetworkServiceImplTest {
     }
 
     @Test
+    fun testJsonErrorBodyWithoutStatusCodeFallsBackToHttpStatus() {
+        val payloadJson = JSONObject(ErrorMocks.Payload).apply {
+            remove(VCLError.KeyStatusCode)
+        }
+
+        val error = sendFailure(
+            payload = payloadJson.toString(),
+            contentType = Request.ContentTypeApplicationJson,
+            responseCode = 422
+        )
+
+        assertEquals(
+            VCLError(
+                payload = payloadJson.toString(),
+                error = ErrorMocks.Error,
+                errorCode = ErrorMocks.ErrorCode,
+                requestId = ErrorMocks.RequestId,
+                message = ErrorMocks.Message,
+                statusCode = 422
+            ),
+            error
+        )
+    }
+
+    @Test
     fun testMalformedJsonBodyFallsBackToPlainTextError() {
         val malformedPayload = "{not valid json"
 

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/network/NetworkServiceImplTest.kt
@@ -1,0 +1,204 @@
+/**
+ * Created by OpenAI Codex on 13/04/2026.
+ *
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.velocitycareerlabs.infrastructure.network
+
+import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.error.VCLError
+import io.velocitycareerlabs.api.entities.error.VCLErrorCode
+import io.velocitycareerlabs.impl.data.infrastructure.network.NetworkServiceImpl
+import io.velocitycareerlabs.impl.data.infrastructure.network.Request
+import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.net.URLStreamHandlerFactory
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertEquals
+
+internal class NetworkServiceImplTest {
+    private lateinit var subject: NetworkServiceImpl
+
+    @Before
+    fun setUp() {
+        installMockProtocolFactoryIfNeeded()
+        subject = NetworkServiceImpl()
+    }
+
+    @Test
+    fun testJsonErrorBodyUsesPayloadJsonFactory() {
+        val payloadJson = JSONObject(ErrorMocks.Payload)
+
+        val error = sendFailure(
+            payload = ErrorMocks.Payload,
+            contentType = Request.ContentTypeApplicationJson,
+            responseCode = 400
+        )
+
+        assertEquals(
+            VCLError(
+                payload = payloadJson.toString(),
+                error = ErrorMocks.Error,
+                errorCode = ErrorMocks.ErrorCode,
+                requestId = ErrorMocks.RequestId,
+                message = ErrorMocks.Message,
+                statusCode = ErrorMocks.StatusCode
+            ),
+            error
+        )
+    }
+
+    @Test
+    fun testPlusJsonErrorBodyUsesPayloadJsonFactory() {
+        val payloadJson = JSONObject(ErrorMocks.Payload)
+
+        val error = sendFailure(
+            payload = ErrorMocks.Payload,
+            contentType = "application/problem+json; charset=UTF-8",
+            responseCode = 400
+        )
+
+        assertEquals(
+            VCLError(
+                payload = payloadJson.toString(),
+                error = ErrorMocks.Error,
+                errorCode = ErrorMocks.ErrorCode,
+                requestId = ErrorMocks.RequestId,
+                message = ErrorMocks.Message,
+                statusCode = ErrorMocks.StatusCode
+            ),
+            error
+        )
+    }
+
+    @Test
+    fun testMalformedJsonBodyFallsBackToPlainTextError() {
+        val malformedPayload = "{not valid json"
+
+        val error = sendFailure(
+            payload = malformedPayload,
+            contentType = Request.ContentTypeApplicationJson,
+            responseCode = 502
+        )
+
+        assertEquals(
+            VCLError(
+                payload = malformedPayload,
+                errorCode = VCLErrorCode.SdkError.value,
+                message = malformedPayload,
+                statusCode = 502
+            ),
+            error
+        )
+    }
+
+    @Test
+    fun testPlainTextErrorBodyUsesPlainTextError() {
+        val textPayload = "server error"
+
+        val error = sendFailure(
+            payload = textPayload,
+            contentType = "text/plain",
+            responseCode = 500
+        )
+
+        assertEquals(
+            VCLError(
+                payload = textPayload,
+                errorCode = VCLErrorCode.SdkError.value,
+                message = textPayload,
+                statusCode = 500
+            ),
+            error
+        )
+    }
+
+    private fun sendFailure(
+        payload: String,
+        contentType: String?,
+        responseCode: Int,
+    ): VCLError {
+        nextConnectionFactory = { url ->
+            FakeHttpURLConnection(
+                url = url,
+                responseCodeValue = responseCode,
+                contentTypeValue = contentType,
+                errorPayload = payload
+            )
+        }
+
+        var result: VCLResult<io.velocitycareerlabs.impl.data.infrastructure.network.Response>? = null
+        subject.sendRequest(
+            endpoint = "mockhttp://example.com/error",
+            body = null,
+            contentType = Request.ContentTypeApplicationJson,
+            method = Request.HttpMethod.GET,
+            headers = null,
+            useCaches = false
+        ) {
+            result = it
+        }
+
+        return (result as? VCLResult.Failure)?.error
+            ?: error("Expected NetworkServiceImpl to return VCLResult.Failure")
+    }
+
+    private class FakeHttpURLConnection(
+        url: URL,
+        private val responseCodeValue: Int,
+        private val contentTypeValue: String?,
+        private val errorPayload: String?,
+    ) : HttpURLConnection(url) {
+        override fun connect() = Unit
+
+        override fun disconnect() = Unit
+
+        override fun usingProxy() = false
+
+        override fun getResponseCode(): Int = responseCodeValue
+
+        override fun getContentType(): String? = contentTypeValue
+
+        override fun getErrorStream(): InputStream? =
+            errorPayload?.let { ByteArrayInputStream(it.toByteArray()) }
+
+        override fun getInputStream(): InputStream =
+            ByteArrayInputStream((errorPayload ?: "").toByteArray())
+    }
+
+    private companion object {
+        private const val MockProtocol = "mockhttp"
+        private val isFactoryInstalled = AtomicBoolean(false)
+
+        @Volatile
+        private var nextConnectionFactory: ((URL) -> HttpURLConnection)? = null
+
+        private fun installMockProtocolFactoryIfNeeded() {
+            if (isFactoryInstalled.compareAndSet(false, true)) {
+                URL.setURLStreamHandlerFactory(
+                    URLStreamHandlerFactory { protocol ->
+                        if (protocol == MockProtocol) {
+                            object : URLStreamHandler() {
+                                override fun openConnection(url: URL): URLConnection =
+                                    nextConnectionFactory?.invoke(url)
+                                        ?: error("No connection factory configured for $url")
+                            }
+                        } else {
+                            null
+                        }
+                    }
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

This PR clarifies how `VCLError` is constructed and propagated across the Android SDK.

It deprecates the ambiguous string/payload convenience constructor in favor of explicit intent:
- use named arguments like `message = ...` for human-readable SDK errors
- use `VCLError.fromPayloadJson(...)` only when parsing an upstream JSON payload

It also updates the obvious human-readable call sites to use `message = ...`, moves `NetworkServiceImpl` to content-type based error normalization, and preserves wrapped error fields when `CredentialIssuerVerifierImpl` remaps `errorCode`.

## Why

The existing API made it easy to put human-readable text into `payload` instead of `message`, which produced inconsistent exception behavior and obscured the canonical error text.

There was also at least one lossy wrapper in `CredentialIssuerVerifierImpl` that overwrote `errorCode` while dropping the original `message`, `requestId`, `statusCode`, and `error` fields.

The network layer was also inferring JSON by probing the body instead of trusting response metadata.

## Impact

- SDK-thrown human-readable errors now populate `message` explicitly.
- JSON payload parsing remains available, but is now an explicit API path.
- Network error handling now branches on response `Content-Type`, with a plain-text fallback when a JSON body is malformed.
- Wrapped verifier errors retain more diagnostic detail.

## Validation

- `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.entities.VCLErrorTest`
- `./gradlew VCL:lintDebug`

## Related

- #182
- #183
- #184
- #185