### PR TITLE
[codex] Release 2.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.velocitycareerlabs:vcl:2.7.3' // or latest version
+    implementation 'io.velocitycareerlabs:vcl:2.9.1' // or latest version
     implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
     implementation "androidx.security:security-crypto:1.1.0-alpha07"
 }

--- a/VCL/build.gradle
+++ b/VCL/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 ext {
-    publishCode = 173
-    publishVersion = "2.9.0"
+    publishCode = 174
+    publishVersion = "2.9.1"
     publishArtifactId = "vcl"
     publishGroupId = "io.velocitycareerlabs"
 }


### PR DESCRIPTION
## What changed
- bump the published VCL SDK version from `2.9.0` to `2.9.1`
- increment the Android `publishCode` from `173` to `174`
- update the top-level README install snippet to point at `2.9.1`

## Why
- releases in this repository are created by the `WalletAndroid-SDK-Publish` GitHub Action, which reads `publishVersion` from `VCL/build.gradle`
- this PR prepares the source-of-truth version bump needed before dispatching the workflow with `environment=prod`

## Impact
- merging this PR makes `2.9.1` the next version published by the release workflow
- documentation stays aligned with the artifact version that will be released

## Validation
- `./gradlew :VCL:assembleAllRelease`