### PR TITLE
feat: add native VCLError diagnostics

### DIFF
--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -10,33 +10,14 @@ package io.velocitycareerlabs.api.entities.error
 import io.velocitycareerlabs.impl.extensions.toJsonObject
 import org.json.JSONObject
 
-data class VCLError(
+class VCLError(
     val payload: String? = null,
     val error: String? = null,
     val errorCode: String = VCLErrorCode.SdkError.value,
     val requestId: String? = null,
     override val message: String? = null,
     val statusCode: Int? = null,
-    val diagnostic: Diagnostic? = null,
 ) : Error(message) {
-    data class Diagnostic(
-        val nativePlatform: String = ValueNativePlatformAndroid,
-        val nativeErrorType: String? = null,
-        val nativeCauseType: String? = null,
-        val nativeCauseMessage: String? = null,
-    ) {
-        fun toJsonObject() =
-            JSONObject().apply {
-                putOpt(KeyNativePlatform, nativePlatform)
-                putOpt(KeyNativeErrorType, nativeErrorType)
-                putOpt(KeyNativeCauseType, nativeCauseType)
-                putOpt(KeyNativeCauseMessage, nativeCauseMessage)
-            }
-    }
-
-    private var wrapperStackFramesInternal: List<String>? = null
-    private var causeStackFramesInternal: List<String>? = null
-
     @Deprecated(
         message = "Use named arguments for human-readable text, or VCLError.fromPayloadJson(...) for payload parsing.",
     )
@@ -52,10 +33,7 @@ data class VCLError(
         requestId = payload?.toJsonObject()?.optString(KeyRequestId),
         message = payload?.toJsonObject()?.optString(KeyMessage),
         statusCode = payload?.toJsonObject()?.optInt(KeyStatusCode),
-        diagnostic = captureDiagnostic(nativeErrorType = ValuePayloadDiagnosticType),
-    ) {
-        wrapperStackFramesInternal = captureCurrentStackFrames()
-    }
+    )
 
     constructor(
         exception: Exception,
@@ -65,10 +43,8 @@ data class VCLError(
         errorCode = errorCode,
         message = exception.toString(),
         statusCode = statusCode,
-        diagnostic = captureDiagnostic(exception),
     ) {
-        wrapperStackFramesInternal = exception.stackTrace.toFrameStrings()
-        causeStackFramesInternal = exception.cause?.stackTrace?.toFrameStrings()
+        initCause(exception)
     }
 
     fun toJsonObject() =
@@ -81,10 +57,24 @@ data class VCLError(
             putOpt(KeyStatusCode, statusCode)
         }
 
-    fun toDiagnosticJsonObject() =
-        toJsonObject().apply {
-            putOpt(KeyDiagnostic, diagnostic?.toJsonObject())
-        }
+    fun copy(
+        payload: String? = this.payload,
+        error: String? = this.error,
+        errorCode: String = this.errorCode,
+        requestId: String? = this.requestId,
+        message: String? = this.message,
+        statusCode: Int? = this.statusCode,
+        cause: Throwable? = this.cause,
+    ) = VCLError(
+        payload = payload,
+        error = error,
+        errorCode = errorCode,
+        requestId = requestId,
+        message = message,
+        statusCode = statusCode,
+    ).also {
+        cause?.let(it::initCause)
+    }
 
     companion object CodingKeys {
         fun fromPayloadJson(
@@ -98,31 +88,7 @@ data class VCLError(
             requestId = payloadJson.optNullableString(KeyRequestId),
             message = payloadJson.optNullableString(KeyMessage),
             statusCode = payloadJson.optNullableInt(KeyStatusCode),
-            diagnostic = captureDiagnostic(nativeErrorType = ValuePayloadDiagnosticType),
-        ).also {
-            it.wrapperStackFramesInternal = captureCurrentStackFrames()
-        }
-
-        private fun captureDiagnostic(exception: Exception) =
-            captureDiagnostic(
-                nativeErrorType = exception::class.java.name,
-                nativeCauseType = exception.cause?.javaClass?.name,
-                nativeCauseMessage = exception.cause?.message ?: exception.cause?.toString(),
-            )
-
-        private fun captureDiagnostic(
-            nativeErrorType: String,
-            nativeCauseType: String? = null,
-            nativeCauseMessage: String? = null,
-        ) = Diagnostic(
-            nativeErrorType = nativeErrorType,
-            nativeCauseType = nativeCauseType,
-            nativeCauseMessage = nativeCauseMessage,
         )
-
-        private fun captureCurrentStackFrames() = Throwable().stackTrace.toFrameStrings()
-
-        private fun Array<StackTraceElement>.toFrameStrings() = map { it.toString() }
 
         private fun JSONObject?.optNullableString(key: String): String? =
             takeIf { it?.has(key) == true && !it.isNull(key) }?.optString(key)
@@ -136,12 +102,5 @@ data class VCLError(
         const val KeyRequestId = "requestId"
         const val KeyMessage = "message"
         const val KeyStatusCode = "statusCode"
-        const val KeyDiagnostic = "diagnostic"
-        const val KeyNativePlatform = "nativePlatform"
-        const val KeyNativeErrorType = "nativeErrorType"
-        const val KeyNativeCauseType = "nativeCauseType"
-        const val KeyNativeCauseMessage = "nativeCauseMessage"
-        const val ValueNativePlatformAndroid = "android"
-        const val ValuePayloadDiagnosticType = "VCLErrorPayload"
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -17,7 +17,8 @@ class VCLError(
     val requestId: String? = null,
     override val message: String? = null,
     val statusCode: Int? = null,
-) : Error(message) {
+    cause: Throwable? = null,
+) : Error(message, cause) {
     @Deprecated(
         message = "Use named arguments for human-readable text, or VCLError.fromPayloadJson(...) for payload parsing.",
     )
@@ -43,9 +44,8 @@ class VCLError(
         errorCode = errorCode,
         message = exception.toString(),
         statusCode = statusCode,
-    ) {
-        initCause(exception)
-    }
+        cause = exception,
+    )
 
     fun toJsonObject() =
         JSONObject().apply {
@@ -72,9 +72,8 @@ class VCLError(
         requestId = requestId,
         message = message,
         statusCode = statusCode,
-    ).also {
-        cause?.let(it::initCause)
-    }
+        cause = cause,
+    )
 
     companion object CodingKeys {
         fun fromPayloadJson(

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -8,6 +8,7 @@
 package io.velocitycareerlabs.api.entities.error
 
 import io.velocitycareerlabs.impl.extensions.toJsonObject
+import org.json.JSONArray
 import org.json.JSONObject
 
 data class VCLError(
@@ -17,7 +18,25 @@ data class VCLError(
     val requestId: String? = null,
     override val message: String? = null,
     val statusCode: Int? = null,
+    val diagnostic: Diagnostic? = null,
 ) : Error(message) {
+    data class Diagnostic(
+        val nativePlatform: String = ValueNativePlatformAndroid,
+        val nativeErrorType: String? = null,
+        val nativeStackFrames: List<String>? = null,
+        val nativeStackTop: String? = null,
+        val nativeCause: String? = null,
+    ) {
+        fun toJsonObject() =
+            JSONObject().apply {
+                putOpt(KeyNativePlatform, nativePlatform)
+                putOpt(KeyNativeErrorType, nativeErrorType)
+                putOpt(KeyNativeStackFrames, nativeStackFrames?.let { JSONArray(it) })
+                putOpt(KeyNativeStackTop, nativeStackTop)
+                putOpt(KeyNativeCause, nativeCause)
+            }
+    }
+
     @Deprecated(
         message = "Use named arguments for human-readable text, or VCLError.fromPayloadJson(...) for payload parsing.",
     )
@@ -33,6 +52,7 @@ data class VCLError(
         requestId = payload?.toJsonObject()?.optString(KeyRequestId),
         message = payload?.toJsonObject()?.optString(KeyMessage),
         statusCode = payload?.toJsonObject()?.optInt(KeyStatusCode),
+        diagnostic = captureDiagnostic(nativeErrorType = ValuePayloadDiagnosticType),
     )
 
     constructor(
@@ -43,6 +63,7 @@ data class VCLError(
         errorCode = errorCode,
         message = exception.toString(),
         statusCode = statusCode,
+        diagnostic = captureDiagnostic(exception),
     )
 
     fun toJsonObject() =
@@ -53,6 +74,7 @@ data class VCLError(
             putOpt(KeyRequestId, requestId)
             putOpt(KeyMessage, message)
             putOpt(KeyStatusCode, statusCode)
+            putOpt(KeyDiagnostic, diagnostic?.toJsonObject())
         }
 
     companion object CodingKeys {
@@ -67,6 +89,25 @@ data class VCLError(
             requestId = payloadJson.optNullableString(KeyRequestId),
             message = payloadJson.optNullableString(KeyMessage),
             statusCode = payloadJson.optNullableInt(KeyStatusCode),
+            diagnostic = captureDiagnostic(nativeErrorType = ValuePayloadDiagnosticType),
+        )
+
+        private fun captureDiagnostic(exception: Exception) =
+            captureDiagnostic(
+                nativeErrorType = exception::class.java.name,
+                nativeCause = exception.cause?.toString(),
+                nativeStackFrames = exception.stackTrace.map { it.toString() },
+            )
+
+        private fun captureDiagnostic(
+            nativeErrorType: String,
+            nativeCause: String? = null,
+            nativeStackFrames: List<String> = Throwable().stackTrace.map { it.toString() },
+        ) = Diagnostic(
+            nativeErrorType = nativeErrorType,
+            nativeStackFrames = nativeStackFrames.ifEmpty { null },
+            nativeStackTop = nativeStackFrames.firstOrNull(),
+            nativeCause = nativeCause,
         )
 
         private fun JSONObject?.optNullableString(key: String): String? =
@@ -81,5 +122,13 @@ data class VCLError(
         const val KeyRequestId = "requestId"
         const val KeyMessage = "message"
         const val KeyStatusCode = "statusCode"
+        const val KeyDiagnostic = "diagnostic"
+        const val KeyNativePlatform = "nativePlatform"
+        const val KeyNativeErrorType = "nativeErrorType"
+        const val KeyNativeStackFrames = "nativeStackFrames"
+        const val KeyNativeStackTop = "nativeStackTop"
+        const val KeyNativeCause = "nativeCause"
+        const val ValueNativePlatformAndroid = "android"
+        const val ValuePayloadDiagnosticType = "VCLErrorPayload"
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -24,7 +24,6 @@ data class VCLError(
         val nativeErrorType: String? = null,
         val nativeCauseType: String? = null,
         val nativeCauseMessage: String? = null,
-        val nativeCauseStackTop: String? = null,
     ) {
         fun toJsonObject() =
             JSONObject().apply {
@@ -32,7 +31,6 @@ data class VCLError(
                 putOpt(KeyNativeErrorType, nativeErrorType)
                 putOpt(KeyNativeCauseType, nativeCauseType)
                 putOpt(KeyNativeCauseMessage, nativeCauseMessage)
-                putOpt(KeyNativeCauseStackTop, nativeCauseStackTop)
             }
     }
 
@@ -110,19 +108,16 @@ data class VCLError(
                 nativeErrorType = exception::class.java.name,
                 nativeCauseType = exception.cause?.javaClass?.name,
                 nativeCauseMessage = exception.cause?.message ?: exception.cause?.toString(),
-                nativeCauseStackTop = exception.cause?.stackTrace?.toFrameStrings()?.firstOrNull(),
             )
 
         private fun captureDiagnostic(
             nativeErrorType: String,
             nativeCauseType: String? = null,
             nativeCauseMessage: String? = null,
-            nativeCauseStackTop: String? = null,
         ) = Diagnostic(
             nativeErrorType = nativeErrorType,
             nativeCauseType = nativeCauseType,
             nativeCauseMessage = nativeCauseMessage,
-            nativeCauseStackTop = nativeCauseStackTop,
         )
 
         private fun captureCurrentStackFrames() = Throwable().stackTrace.toFrameStrings()
@@ -146,7 +141,6 @@ data class VCLError(
         const val KeyNativeErrorType = "nativeErrorType"
         const val KeyNativeCauseType = "nativeCauseType"
         const val KeyNativeCauseMessage = "nativeCauseMessage"
-        const val KeyNativeCauseStackTop = "nativeCauseStackTop"
         const val ValueNativePlatformAndroid = "android"
         const val ValuePayloadDiagnosticType = "VCLErrorPayload"
     }

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -8,7 +8,6 @@
 package io.velocitycareerlabs.api.entities.error
 
 import io.velocitycareerlabs.impl.extensions.toJsonObject
-import org.json.JSONArray
 import org.json.JSONObject
 
 data class VCLError(
@@ -23,19 +22,22 @@ data class VCLError(
     data class Diagnostic(
         val nativePlatform: String = ValueNativePlatformAndroid,
         val nativeErrorType: String? = null,
-        val nativeStackFrames: List<String>? = null,
-        val nativeStackTop: String? = null,
-        val nativeCause: String? = null,
+        val nativeCauseType: String? = null,
+        val nativeCauseMessage: String? = null,
+        val nativeCauseStackTop: String? = null,
     ) {
         fun toJsonObject() =
             JSONObject().apply {
                 putOpt(KeyNativePlatform, nativePlatform)
                 putOpt(KeyNativeErrorType, nativeErrorType)
-                putOpt(KeyNativeStackFrames, nativeStackFrames?.let { JSONArray(it) })
-                putOpt(KeyNativeStackTop, nativeStackTop)
-                putOpt(KeyNativeCause, nativeCause)
+                putOpt(KeyNativeCauseType, nativeCauseType)
+                putOpt(KeyNativeCauseMessage, nativeCauseMessage)
+                putOpt(KeyNativeCauseStackTop, nativeCauseStackTop)
             }
     }
+
+    private var wrapperStackFramesInternal: List<String>? = null
+    private var causeStackFramesInternal: List<String>? = null
 
     @Deprecated(
         message = "Use named arguments for human-readable text, or VCLError.fromPayloadJson(...) for payload parsing.",
@@ -53,7 +55,9 @@ data class VCLError(
         message = payload?.toJsonObject()?.optString(KeyMessage),
         statusCode = payload?.toJsonObject()?.optInt(KeyStatusCode),
         diagnostic = captureDiagnostic(nativeErrorType = ValuePayloadDiagnosticType),
-    )
+    ) {
+        wrapperStackFramesInternal = captureCurrentStackFrames()
+    }
 
     constructor(
         exception: Exception,
@@ -64,7 +68,10 @@ data class VCLError(
         message = exception.toString(),
         statusCode = statusCode,
         diagnostic = captureDiagnostic(exception),
-    )
+    ) {
+        wrapperStackFramesInternal = exception.stackTrace.toFrameStrings()
+        causeStackFramesInternal = exception.cause?.stackTrace?.toFrameStrings()
+    }
 
     fun toJsonObject() =
         JSONObject().apply {
@@ -94,33 +101,33 @@ data class VCLError(
             message = payloadJson.optNullableString(KeyMessage),
             statusCode = payloadJson.optNullableInt(KeyStatusCode),
             diagnostic = captureDiagnostic(nativeErrorType = ValuePayloadDiagnosticType),
-        )
+        ).also {
+            it.wrapperStackFramesInternal = captureCurrentStackFrames()
+        }
 
         private fun captureDiagnostic(exception: Exception) =
             captureDiagnostic(
                 nativeErrorType = exception::class.java.name,
-                nativeCause = exception.cause?.toString(),
-                nativeStackFrames = exception.stackTrace.toUsefulStackFrames(),
+                nativeCauseType = exception.cause?.javaClass?.name,
+                nativeCauseMessage = exception.cause?.message ?: exception.cause?.toString(),
+                nativeCauseStackTop = exception.cause?.stackTrace?.toFrameStrings()?.firstOrNull(),
             )
 
         private fun captureDiagnostic(
             nativeErrorType: String,
-            nativeCause: String? = null,
-            nativeStackFrames: List<String> = Throwable().stackTrace.toUsefulStackFrames(),
+            nativeCauseType: String? = null,
+            nativeCauseMessage: String? = null,
+            nativeCauseStackTop: String? = null,
         ) = Diagnostic(
             nativeErrorType = nativeErrorType,
-            nativeStackFrames = nativeStackFrames.ifEmpty { null },
-            nativeStackTop = nativeStackFrames.firstOrNull(),
-            nativeCause = nativeCause,
+            nativeCauseType = nativeCauseType,
+            nativeCauseMessage = nativeCauseMessage,
+            nativeCauseStackTop = nativeCauseStackTop,
         )
 
-        private fun Array<StackTraceElement>.toUsefulStackFrames() =
-            mapNotNull {
-                it.toString().takeUnless { frame ->
-                    frame.contains("${VCLError::class.java.name}.") ||
-                        frame.contains("${VCLError::class.java.name}\$Companion.")
-                }
-            }.take(MaxDiagnosticStackFrames)
+        private fun captureCurrentStackFrames() = Throwable().stackTrace.toFrameStrings()
+
+        private fun Array<StackTraceElement>.toFrameStrings() = map { it.toString() }
 
         private fun JSONObject?.optNullableString(key: String): String? =
             takeIf { it?.has(key) == true && !it.isNull(key) }?.optString(key)
@@ -137,11 +144,10 @@ data class VCLError(
         const val KeyDiagnostic = "diagnostic"
         const val KeyNativePlatform = "nativePlatform"
         const val KeyNativeErrorType = "nativeErrorType"
-        const val KeyNativeStackFrames = "nativeStackFrames"
-        const val KeyNativeStackTop = "nativeStackTop"
-        const val KeyNativeCause = "nativeCause"
+        const val KeyNativeCauseType = "nativeCauseType"
+        const val KeyNativeCauseMessage = "nativeCauseMessage"
+        const val KeyNativeCauseStackTop = "nativeCauseStackTop"
         const val ValueNativePlatformAndroid = "android"
         const val ValuePayloadDiagnosticType = "VCLErrorPayload"
-        const val MaxDiagnosticStackFrames = 5
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -10,14 +10,14 @@ package io.velocitycareerlabs.api.entities.error
 import io.velocitycareerlabs.impl.extensions.toJsonObject
 import org.json.JSONObject
 
-class VCLError(
+data class VCLError(
     val payload: String? = null,
     val error: String? = null,
     val errorCode: String = VCLErrorCode.SdkError.value,
     val requestId: String? = null,
     override val message: String? = null,
     val statusCode: Int? = null,
-    cause: Throwable? = null,
+    override val cause: Throwable? = null,
 ) : Error(message, cause) {
     @Deprecated(
         message = "Use named arguments for human-readable text, or VCLError.fromPayloadJson(...) for payload parsing.",
@@ -56,24 +56,6 @@ class VCLError(
             putOpt(KeyMessage, message)
             putOpt(KeyStatusCode, statusCode)
         }
-
-    fun copy(
-        payload: String? = this.payload,
-        error: String? = this.error,
-        errorCode: String = this.errorCode,
-        requestId: String? = this.requestId,
-        message: String? = this.message,
-        statusCode: Int? = this.statusCode,
-        cause: Throwable? = this.cause,
-    ) = VCLError(
-        payload = payload,
-        error = error,
-        errorCode = errorCode,
-        requestId = requestId,
-        message = message,
-        statusCode = statusCode,
-        cause = cause,
-    )
 
     companion object CodingKeys {
         fun fromPayloadJson(

--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLError.kt
@@ -74,6 +74,10 @@ data class VCLError(
             putOpt(KeyRequestId, requestId)
             putOpt(KeyMessage, message)
             putOpt(KeyStatusCode, statusCode)
+        }
+
+    fun toDiagnosticJsonObject() =
+        toJsonObject().apply {
             putOpt(KeyDiagnostic, diagnostic?.toJsonObject())
         }
 
@@ -96,19 +100,27 @@ data class VCLError(
             captureDiagnostic(
                 nativeErrorType = exception::class.java.name,
                 nativeCause = exception.cause?.toString(),
-                nativeStackFrames = exception.stackTrace.map { it.toString() },
+                nativeStackFrames = exception.stackTrace.toUsefulStackFrames(),
             )
 
         private fun captureDiagnostic(
             nativeErrorType: String,
             nativeCause: String? = null,
-            nativeStackFrames: List<String> = Throwable().stackTrace.map { it.toString() },
+            nativeStackFrames: List<String> = Throwable().stackTrace.toUsefulStackFrames(),
         ) = Diagnostic(
             nativeErrorType = nativeErrorType,
             nativeStackFrames = nativeStackFrames.ifEmpty { null },
             nativeStackTop = nativeStackFrames.firstOrNull(),
             nativeCause = nativeCause,
         )
+
+        private fun Array<StackTraceElement>.toUsefulStackFrames() =
+            mapNotNull {
+                it.toString().takeUnless { frame ->
+                    frame.contains("${VCLError::class.java.name}.") ||
+                        frame.contains("${VCLError::class.java.name}\$Companion.")
+                }
+            }.take(MaxDiagnosticStackFrames)
 
         private fun JSONObject?.optNullableString(key: String): String? =
             takeIf { it?.has(key) == true && !it.isNull(key) }?.optString(key)
@@ -130,5 +142,6 @@ data class VCLError(
         const val KeyNativeCause = "nativeCause"
         const val ValueNativePlatformAndroid = "android"
         const val ValuePayloadDiagnosticType = "VCLErrorPayload"
+        const val MaxDiagnosticStackFrames = 5
     }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -41,8 +41,8 @@ class VCLErrorTest {
             requestId = ErrorMocks.RequestId,
             message = ErrorMocks.Message,
             statusCode = ErrorMocks.StatusCode,
+            cause = cause,
         )
-        error.initCause(cause)
 
         assertEquals(ErrorMocks.Error, error.error)
         assertEquals(ErrorMocks.ErrorCode, error.errorCode)

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -20,7 +20,6 @@ class VCLErrorTest {
         nativeErrorType = "NativeErrorType",
         nativeCauseType = "NativeCauseType",
         nativeCauseMessage = "NativeCauseMessage",
-        nativeCauseStackTop = "NativeCauseStackTop",
     )
 
     @Test
@@ -38,7 +37,6 @@ class VCLErrorTest {
         assertEquals(VCLError.ValuePayloadDiagnosticType, error.diagnostic?.nativeErrorType)
         assertEquals(null, error.diagnostic?.nativeCauseType)
         assertEquals(null, error.diagnostic?.nativeCauseMessage)
-        assertEquals(null, error.diagnostic?.nativeCauseStackTop)
     }
 
     @Test
@@ -72,7 +70,6 @@ class VCLErrorTest {
         assertEquals(IllegalStateException::class.java.name, error.diagnostic?.nativeErrorType)
         assertEquals(IllegalArgumentException::class.java.name, error.diagnostic?.nativeCauseType)
         assertEquals("cause", error.diagnostic?.nativeCauseMessage)
-        assertEquals(exception.cause?.stackTrace?.firstOrNull()?.toString(), error.diagnostic?.nativeCauseStackTop)
     }
 
     @Test
@@ -159,7 +156,6 @@ class VCLErrorTest {
                     .put(VCLError.KeyNativeErrorType, diagnostic.nativeErrorType)
                     .put(VCLError.KeyNativeCauseType, diagnostic.nativeCauseType)
                     .put(VCLError.KeyNativeCauseMessage, diagnostic.nativeCauseMessage)
-                    .put(VCLError.KeyNativeCauseStackTop, diagnostic.nativeCauseStackTop)
             )
 
         assertTrue(errorJsonObject.similar(expectedJsonObject))

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -10,7 +10,6 @@ package io.velocitycareerlabs.entities
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.api.entities.error.VCLErrorCode
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
-import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -19,9 +18,9 @@ import org.junit.Test
 class VCLErrorTest {
     private val diagnostic = VCLError.Diagnostic(
         nativeErrorType = "NativeErrorType",
-        nativeStackFrames = listOf("frame 1", "frame 2"),
-        nativeStackTop = "frame 1",
-        nativeCause = "NativeCause",
+        nativeCauseType = "NativeCauseType",
+        nativeCauseMessage = "NativeCauseMessage",
+        nativeCauseStackTop = "NativeCauseStackTop",
     )
 
     @Test
@@ -37,9 +36,9 @@ class VCLErrorTest {
         assertEquals(ErrorMocks.StatusCode, error.statusCode)
         assertEquals(VCLError.ValueNativePlatformAndroid, error.diagnostic?.nativePlatform)
         assertEquals(VCLError.ValuePayloadDiagnosticType, error.diagnostic?.nativeErrorType)
-        assertTrue(error.diagnostic?.nativeStackFrames?.isNotEmpty() == true)
-        assertEquals(error.diagnostic?.nativeStackFrames?.first(), error.diagnostic?.nativeStackTop)
-        assertTrue((error.diagnostic?.nativeStackFrames?.count() ?: 0) <= VCLError.MaxDiagnosticStackFrames)
+        assertEquals(null, error.diagnostic?.nativeCauseType)
+        assertEquals(null, error.diagnostic?.nativeCauseMessage)
+        assertEquals(null, error.diagnostic?.nativeCauseStackTop)
     }
 
     @Test
@@ -71,9 +70,9 @@ class VCLErrorTest {
         assertEquals(ErrorMocks.StatusCode, error.statusCode)
         assertEquals(VCLError.ValueNativePlatformAndroid, error.diagnostic?.nativePlatform)
         assertEquals(IllegalStateException::class.java.name, error.diagnostic?.nativeErrorType)
-        assertEquals(exception.stackTrace.firstOrNull()?.toString(), error.diagnostic?.nativeStackTop)
-        assertEquals(exception.cause?.toString(), error.diagnostic?.nativeCause)
-        assertEquals(exception.stackTrace.map { it.toString() }.take(VCLError.MaxDiagnosticStackFrames), error.diagnostic?.nativeStackFrames)
+        assertEquals(IllegalArgumentException::class.java.name, error.diagnostic?.nativeCauseType)
+        assertEquals("cause", error.diagnostic?.nativeCauseMessage)
+        assertEquals(exception.cause?.stackTrace?.firstOrNull()?.toString(), error.diagnostic?.nativeCauseStackTop)
     }
 
     @Test
@@ -111,8 +110,6 @@ class VCLErrorTest {
                 JSONObject()
                     .put(VCLError.KeyNativePlatform, VCLError.ValueNativePlatformAndroid)
                     .put(VCLError.KeyNativeErrorType, VCLError.ValuePayloadDiagnosticType)
-                    .put(VCLError.KeyNativeStackFrames, error.diagnostic?.nativeStackFrames?.let { JSONArray(it) })
-                    .put(VCLError.KeyNativeStackTop, error.diagnostic?.nativeStackTop)
             )
         }))
     }
@@ -160,9 +157,9 @@ class VCLErrorTest {
                 JSONObject()
                     .put(VCLError.KeyNativePlatform, VCLError.ValueNativePlatformAndroid)
                     .put(VCLError.KeyNativeErrorType, diagnostic.nativeErrorType)
-                    .put(VCLError.KeyNativeStackFrames, JSONArray(diagnostic.nativeStackFrames))
-                    .put(VCLError.KeyNativeStackTop, diagnostic.nativeStackTop)
-                    .put(VCLError.KeyNativeCause, diagnostic.nativeCause)
+                    .put(VCLError.KeyNativeCauseType, diagnostic.nativeCauseType)
+                    .put(VCLError.KeyNativeCauseMessage, diagnostic.nativeCauseMessage)
+                    .put(VCLError.KeyNativeCauseStackTop, diagnostic.nativeCauseStackTop)
             )
 
         assertTrue(errorJsonObject.similar(expectedJsonObject))

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -12,16 +12,12 @@ import io.velocitycareerlabs.api.entities.error.VCLErrorCode
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VCLErrorTest {
-    private val diagnostic = VCLError.Diagnostic(
-        nativeErrorType = "NativeErrorType",
-        nativeCauseType = "NativeCauseType",
-        nativeCauseMessage = "NativeCauseMessage",
-    )
-
     @Test
     fun testErrorFromPayload() {
         val payloadJson = JSONObject(ErrorMocks.Payload)
@@ -33,29 +29,27 @@ class VCLErrorTest {
         assertEquals(ErrorMocks.RequestId, error.requestId)
         assertEquals(ErrorMocks.Message, error.message)
         assertEquals(ErrorMocks.StatusCode, error.statusCode)
-        assertEquals(VCLError.ValueNativePlatformAndroid, error.diagnostic?.nativePlatform)
-        assertEquals(VCLError.ValuePayloadDiagnosticType, error.diagnostic?.nativeErrorType)
-        assertEquals(null, error.diagnostic?.nativeCauseType)
-        assertEquals(null, error.diagnostic?.nativeCauseMessage)
+        assertNull(error.cause)
     }
 
     @Test
     fun testErrorFromProperties() {
+        val cause = IllegalStateException("manual cause")
         val error = VCLError(
             error = ErrorMocks.Error,
             errorCode = ErrorMocks.ErrorCode,
             requestId = ErrorMocks.RequestId,
             message = ErrorMocks.Message,
             statusCode = ErrorMocks.StatusCode,
-            diagnostic = diagnostic,
         )
+        error.initCause(cause)
 
         assertEquals(ErrorMocks.Error, error.error)
         assertEquals(ErrorMocks.ErrorCode, error.errorCode)
         assertEquals(ErrorMocks.RequestId, error.requestId)
         assertEquals(ErrorMocks.Message, error.message)
         assertEquals(ErrorMocks.StatusCode, error.statusCode)
-        assertEquals(diagnostic, error.diagnostic)
+        assertSame(cause, error.cause)
     }
 
     @Test
@@ -66,10 +60,7 @@ class VCLErrorTest {
         assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
         assertEquals(exception.toString(), error.message)
         assertEquals(ErrorMocks.StatusCode, error.statusCode)
-        assertEquals(VCLError.ValueNativePlatformAndroid, error.diagnostic?.nativePlatform)
-        assertEquals(IllegalStateException::class.java.name, error.diagnostic?.nativeErrorType)
-        assertEquals(IllegalArgumentException::class.java.name, error.diagnostic?.nativeCauseType)
-        assertEquals("cause", error.diagnostic?.nativeCauseMessage)
+        assertSame(exception, error.cause)
     }
 
     @Test
@@ -89,29 +80,6 @@ class VCLErrorTest {
     }
 
     @Test
-    fun testErrorToDiagnosticJsonFromPayload() {
-        val payloadJson = JSONObject(ErrorMocks.Payload)
-        val error = VCLError.fromPayloadJson(payloadJson)
-        val errorJsonObject = error.toDiagnosticJsonObject()
-        val expectedJsonObject = JSONObject()
-            .put(VCLError.KeyPayload, payloadJson.toString())
-            .put(VCLError.KeyError, ErrorMocks.Error)
-            .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
-            .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
-            .put(VCLError.KeyMessage, ErrorMocks.Message)
-            .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
-
-        assertTrue(errorJsonObject.similar(expectedJsonObject.apply {
-            put(
-                VCLError.KeyDiagnostic,
-                JSONObject()
-                    .put(VCLError.KeyNativePlatform, VCLError.ValueNativePlatformAndroid)
-                    .put(VCLError.KeyNativeErrorType, VCLError.ValuePayloadDiagnosticType)
-            )
-        }))
-    }
-
-    @Test
     fun testErrorToJsonFromProperties() {
         val error = VCLError(
             error = ErrorMocks.Error,
@@ -119,7 +87,6 @@ class VCLErrorTest {
             requestId = ErrorMocks.RequestId,
             message = ErrorMocks.Message,
             statusCode = ErrorMocks.StatusCode,
-            diagnostic = diagnostic,
         )
         val errorJsonObject = error.toJsonObject()
         val expectedJsonObject = JSONObject()
@@ -128,35 +95,6 @@ class VCLErrorTest {
             .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
             .put(VCLError.KeyMessage, ErrorMocks.Message)
             .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
-
-        assertTrue(errorJsonObject.similar(expectedJsonObject))
-    }
-
-    @Test
-    fun testErrorToDiagnosticJsonFromProperties() {
-        val error = VCLError(
-            error = ErrorMocks.Error,
-            errorCode = ErrorMocks.ErrorCode,
-            requestId = ErrorMocks.RequestId,
-            message = ErrorMocks.Message,
-            statusCode = ErrorMocks.StatusCode,
-            diagnostic = diagnostic,
-        )
-        val errorJsonObject = error.toDiagnosticJsonObject()
-        val expectedJsonObject = JSONObject()
-            .put(VCLError.KeyError, ErrorMocks.Error)
-            .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
-            .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
-            .put(VCLError.KeyMessage, ErrorMocks.Message)
-            .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
-            .put(
-                VCLError.KeyDiagnostic,
-                JSONObject()
-                    .put(VCLError.KeyNativePlatform, VCLError.ValueNativePlatformAndroid)
-                    .put(VCLError.KeyNativeErrorType, diagnostic.nativeErrorType)
-                    .put(VCLError.KeyNativeCauseType, diagnostic.nativeCauseType)
-                    .put(VCLError.KeyNativeCauseMessage, diagnostic.nativeCauseMessage)
-            )
 
         assertTrue(errorJsonObject.similar(expectedJsonObject))
     }

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -39,6 +39,7 @@ class VCLErrorTest {
         assertEquals(VCLError.ValuePayloadDiagnosticType, error.diagnostic?.nativeErrorType)
         assertTrue(error.diagnostic?.nativeStackFrames?.isNotEmpty() == true)
         assertEquals(error.diagnostic?.nativeStackFrames?.first(), error.diagnostic?.nativeStackTop)
+        assertTrue((error.diagnostic?.nativeStackFrames?.count() ?: 0) <= VCLError.MaxDiagnosticStackFrames)
     }
 
     @Test
@@ -72,7 +73,7 @@ class VCLErrorTest {
         assertEquals(IllegalStateException::class.java.name, error.diagnostic?.nativeErrorType)
         assertEquals(exception.stackTrace.firstOrNull()?.toString(), error.diagnostic?.nativeStackTop)
         assertEquals(exception.cause?.toString(), error.diagnostic?.nativeCause)
-        assertEquals(exception.stackTrace.map { it.toString() }, error.diagnostic?.nativeStackFrames)
+        assertEquals(exception.stackTrace.map { it.toString() }.take(VCLError.MaxDiagnosticStackFrames), error.diagnostic?.nativeStackFrames)
     }
 
     @Test
@@ -80,6 +81,22 @@ class VCLErrorTest {
         val payloadJson = JSONObject(ErrorMocks.Payload)
         val error = VCLError.fromPayloadJson(payloadJson)
         val errorJsonObject = error.toJsonObject()
+        val expectedJsonObject = JSONObject()
+            .put(VCLError.KeyPayload, payloadJson.toString())
+            .put(VCLError.KeyError, ErrorMocks.Error)
+            .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
+            .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
+            .put(VCLError.KeyMessage, ErrorMocks.Message)
+            .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
+
+        assertTrue(errorJsonObject.similar(expectedJsonObject))
+    }
+
+    @Test
+    fun testErrorToDiagnosticJsonFromPayload() {
+        val payloadJson = JSONObject(ErrorMocks.Payload)
+        val error = VCLError.fromPayloadJson(payloadJson)
+        val errorJsonObject = error.toDiagnosticJsonObject()
         val expectedJsonObject = JSONObject()
             .put(VCLError.KeyPayload, payloadJson.toString())
             .put(VCLError.KeyError, ErrorMocks.Error)
@@ -111,6 +128,27 @@ class VCLErrorTest {
             diagnostic = diagnostic,
         )
         val errorJsonObject = error.toJsonObject()
+        val expectedJsonObject = JSONObject()
+            .put(VCLError.KeyError, ErrorMocks.Error)
+            .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)
+            .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
+            .put(VCLError.KeyMessage, ErrorMocks.Message)
+            .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
+
+        assertTrue(errorJsonObject.similar(expectedJsonObject))
+    }
+
+    @Test
+    fun testErrorToDiagnosticJsonFromProperties() {
+        val error = VCLError(
+            error = ErrorMocks.Error,
+            errorCode = ErrorMocks.ErrorCode,
+            requestId = ErrorMocks.RequestId,
+            message = ErrorMocks.Message,
+            statusCode = ErrorMocks.StatusCode,
+            diagnostic = diagnostic,
+        )
+        val errorJsonObject = error.toDiagnosticJsonObject()
         val expectedJsonObject = JSONObject()
             .put(VCLError.KeyError, ErrorMocks.Error)
             .put(VCLError.KeyErrorCode, ErrorMocks.ErrorCode)

--- a/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/entities/VCLErrorTest.kt
@@ -8,28 +8,37 @@
 package io.velocitycareerlabs.entities
 
 import io.velocitycareerlabs.api.entities.error.VCLError
+import io.velocitycareerlabs.api.entities.error.VCLErrorCode
 import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VCLErrorTest {
+    private val diagnostic = VCLError.Diagnostic(
+        nativeErrorType = "NativeErrorType",
+        nativeStackFrames = listOf("frame 1", "frame 2"),
+        nativeStackTop = "frame 1",
+        nativeCause = "NativeCause",
+    )
 
     @Test
     fun testErrorFromPayload() {
         val payloadJson = JSONObject(ErrorMocks.Payload)
         val error = VCLError.fromPayloadJson(payloadJson)
-        val expectedError = VCLError(
-            payload = payloadJson.toString(),
-            error = ErrorMocks.Error,
-            errorCode = ErrorMocks.ErrorCode,
-            requestId = ErrorMocks.RequestId,
-            message = ErrorMocks.Message,
-            statusCode = ErrorMocks.StatusCode
-        )
 
-        assertEquals(expectedError, error)
+        assertEquals(payloadJson.toString(), error.payload)
+        assertEquals(ErrorMocks.Error, error.error)
+        assertEquals(ErrorMocks.ErrorCode, error.errorCode)
+        assertEquals(ErrorMocks.RequestId, error.requestId)
+        assertEquals(ErrorMocks.Message, error.message)
+        assertEquals(ErrorMocks.StatusCode, error.statusCode)
+        assertEquals(VCLError.ValueNativePlatformAndroid, error.diagnostic?.nativePlatform)
+        assertEquals(VCLError.ValuePayloadDiagnosticType, error.diagnostic?.nativeErrorType)
+        assertTrue(error.diagnostic?.nativeStackFrames?.isNotEmpty() == true)
+        assertEquals(error.diagnostic?.nativeStackFrames?.first(), error.diagnostic?.nativeStackTop)
     }
 
     @Test
@@ -39,17 +48,31 @@ class VCLErrorTest {
             errorCode = ErrorMocks.ErrorCode,
             requestId = ErrorMocks.RequestId,
             message = ErrorMocks.Message,
-            statusCode = ErrorMocks.StatusCode
-        )
-        val expectedError = VCLError(
-            error = ErrorMocks.Error,
-            errorCode = ErrorMocks.ErrorCode,
-            requestId = ErrorMocks.RequestId,
-            message = ErrorMocks.Message,
-            statusCode = ErrorMocks.StatusCode
+            statusCode = ErrorMocks.StatusCode,
+            diagnostic = diagnostic,
         )
 
-        assertEquals(expectedError, error)
+        assertEquals(ErrorMocks.Error, error.error)
+        assertEquals(ErrorMocks.ErrorCode, error.errorCode)
+        assertEquals(ErrorMocks.RequestId, error.requestId)
+        assertEquals(ErrorMocks.Message, error.message)
+        assertEquals(ErrorMocks.StatusCode, error.statusCode)
+        assertEquals(diagnostic, error.diagnostic)
+    }
+
+    @Test
+    fun testErrorFromException() {
+        val exception = IllegalStateException("boom", IllegalArgumentException("cause"))
+        val error = VCLError(exception = exception, statusCode = ErrorMocks.StatusCode)
+
+        assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+        assertEquals(exception.toString(), error.message)
+        assertEquals(ErrorMocks.StatusCode, error.statusCode)
+        assertEquals(VCLError.ValueNativePlatformAndroid, error.diagnostic?.nativePlatform)
+        assertEquals(IllegalStateException::class.java.name, error.diagnostic?.nativeErrorType)
+        assertEquals(exception.stackTrace.firstOrNull()?.toString(), error.diagnostic?.nativeStackTop)
+        assertEquals(exception.cause?.toString(), error.diagnostic?.nativeCause)
+        assertEquals(exception.stackTrace.map { it.toString() }, error.diagnostic?.nativeStackFrames)
     }
 
     @Test
@@ -65,7 +88,16 @@ class VCLErrorTest {
             .put(VCLError.KeyMessage, ErrorMocks.Message)
             .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
 
-        assertTrue(errorJsonObject.similar(expectedJsonObject))
+        assertTrue(errorJsonObject.similar(expectedJsonObject.apply {
+            put(
+                VCLError.KeyDiagnostic,
+                JSONObject()
+                    .put(VCLError.KeyNativePlatform, VCLError.ValueNativePlatformAndroid)
+                    .put(VCLError.KeyNativeErrorType, VCLError.ValuePayloadDiagnosticType)
+                    .put(VCLError.KeyNativeStackFrames, error.diagnostic?.nativeStackFrames?.let { JSONArray(it) })
+                    .put(VCLError.KeyNativeStackTop, error.diagnostic?.nativeStackTop)
+            )
+        }))
     }
 
     @Test
@@ -75,7 +107,8 @@ class VCLErrorTest {
             errorCode = ErrorMocks.ErrorCode,
             requestId = ErrorMocks.RequestId,
             message = ErrorMocks.Message,
-            statusCode = ErrorMocks.StatusCode
+            statusCode = ErrorMocks.StatusCode,
+            diagnostic = diagnostic,
         )
         val errorJsonObject = error.toJsonObject()
         val expectedJsonObject = JSONObject()
@@ -84,6 +117,15 @@ class VCLErrorTest {
             .put(VCLError.KeyRequestId, ErrorMocks.RequestId)
             .put(VCLError.KeyMessage, ErrorMocks.Message)
             .put(VCLError.KeyStatusCode, ErrorMocks.StatusCode)
+            .put(
+                VCLError.KeyDiagnostic,
+                JSONObject()
+                    .put(VCLError.KeyNativePlatform, VCLError.ValueNativePlatformAndroid)
+                    .put(VCLError.KeyNativeErrorType, diagnostic.nativeErrorType)
+                    .put(VCLError.KeyNativeStackFrames, JSONArray(diagnostic.nativeStackFrames))
+                    .put(VCLError.KeyNativeStackTop, diagnostic.nativeStackTop)
+                    .put(VCLError.KeyNativeCause, diagnostic.nativeCause)
+            )
 
         assertTrue(errorJsonObject.similar(expectedJsonObject))
     }


### PR DESCRIPTION
## Summary
- introdcue `cause` model on `VCLError` to track causal exceptions and stack traces
- keep `toJsonObject()` stable-only and leave payload-derived `VCLError`s without a cause


## Testing
- `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.entities.VCLErrorTest`
