### PR TITLE
[codex] Release 2.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.velocitycareerlabs:vcl:2.9.1' // or latest version
+    implementation 'io.velocitycareerlabs:vcl:2.9.2' // or latest version
     implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
     implementation "androidx.security:security-crypto:1.1.0-alpha07"
 }

--- a/VCL/build.gradle
+++ b/VCL/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 ext {
-    publishCode = 174
-    publishVersion = "2.9.1"
+    publishCode = 175
+    publishVersion = "2.9.2"
     publishArtifactId = "vcl"
     publishGroupId = "io.velocitycareerlabs"
 }


### PR DESCRIPTION
## What changed
- bump `VCL` release metadata from `2.9.1` to `2.9.2`
- increment `publishCode` from `174` to `175`
- update the README install snippet to reference `2.9.2`

## Why
- prepares the Android SDK for the `2.9.2` release from `origin/main`
- opens a PR so the repository's `pull_request` GitHub Actions workflow can run the build/tests on this release bump

## Impact
- the SDK release metadata is ready for the next publish flow
- consumers reading the README will see the current intended release version

## Validation
- GitHub Actions PR workflow will run on this PR
- local Gradle verification was not run in this session