### PR TITLE
fix(ci): add GitHub workflow linting

### DIFF
--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -32,20 +32,19 @@ jobs:
       - name: 📝 Get version from build.gradle
         run: |
           VERSION=$(grep 'publishVersion *= *".*"' VCL/build.gradle | sed -n 's/.*publishVersion *= *"\([^"]*\)".*/\1/p')
-          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Found version: $VERSION"
 
       - name: 🔧 Set publication name and POM file name
         run: |
-          PUB_NAME=
-          echo "PUBLICATION_NAME=${{ github.event.inputs.environment == 'rc' && 'rc' || 'release' }}" >> $GITHUB_ENV
-          echo "POM_FILE_NAME=vcl-${{ github.event.inputs.environment == 'rc' && 'rc-' || '' }}${RELEASE_VERSION}.pom" >> $GITHUB_ENV
+          echo "PUBLICATION_NAME=${{ github.event.inputs.environment == 'rc' && 'rc' || 'release' }}" >> "$GITHUB_ENV"
+          echo "POM_FILE_NAME=vcl-${{ github.event.inputs.environment == 'rc' && 'rc-' || '' }}${RELEASE_VERSION}.pom" >> "$GITHUB_ENV"
 
       - name: 🧪 Build AAR + Sources + Javadoc
         run: |
           ./gradlew clean \
             :VCL:assembleAll${{ github.event.inputs.environment == 'rc' && 'Rc' || 'Release' }} \
-            -PprojectVersion=${RELEASE_VERSION} \
+            -PprojectVersion="${RELEASE_VERSION}" \
             -Pprerelease=${{ github.event.inputs.environment == 'rc' }} \
             --stacktrace
 
@@ -61,7 +60,7 @@ jobs:
       - name: 🧪 Generate POM File
         run: |
           ./gradlew :VCL:generatePomFileFor${{ env.PUBLICATION_NAME }}Publication
-          cp VCL/build/publications/${{ env.PUBLICATION_NAME }}/pom-default.xml VCL/target/staging-deploy/io/velocitycareerlabs/vcl/$RELEASE_VERSION/${{ env.POM_FILE_NAME }}
+          cp VCL/build/publications/${{ env.PUBLICATION_NAME }}/pom-default.xml "VCL/target/staging-deploy/io/velocitycareerlabs/vcl/${RELEASE_VERSION}/${{ env.POM_FILE_NAME }}"
 
       - name: 📂 List staged artifacts
         run: |

--- a/.github/workflows/github-workflow-linting.workflow.yml
+++ b/.github/workflows/github-workflow-linting.workflow.yml
@@ -1,0 +1,21 @@
+name: GitHub Workflow Linting
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/**'
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color


### PR DESCRIPTION
## Summary
- add actionlint CI for GitHub workflow changes
- run actionlint through the pinned rhysd/actionlint:1.7.12 Docker image
- enable ShellCheck as part of actionlint and fix the existing workflow shell findings

## Validation
- docker run --rm -v /Users/andresolave/Projects/velocity/WalletAndroid-codex-actionlint-ci:/repo -w /repo rhysd/actionlint:1.7.12 -color