### PR TITLE
[codex] add Android error taxonomy baseline coverage

### DIFF
--- a/VCL/src/main/java/io/velocitycareerlabs/impl/VCLImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/VCLImpl.kt
@@ -15,6 +15,7 @@ import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.impl.domain.models.CredentialTypeSchemasModel
 import io.velocitycareerlabs.api.entities.handleResult
 import io.velocitycareerlabs.api.entities.initialization.VCLInitializationDescriptor
+import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.impl.domain.models.CountriesModel
 import io.velocitycareerlabs.impl.domain.models.CredentialTypesModel
 import io.velocitycareerlabs.impl.domain.usecases.AuthTokenUseCase
@@ -33,9 +34,12 @@ import io.velocitycareerlabs.impl.domain.usecases.VerifiedProfileUseCase
 import io.velocitycareerlabs.impl.utils.InitializationWatcher
 import io.velocitycareerlabs.impl.utils.VCLLog
 import io.velocitycareerlabs.impl.utils.ProfileServiceTypeVerifier
+import java.net.HttpURLConnection
 import kotlin.jvm.Throws
 
-internal class VCLImpl: VCL {
+internal class VCLImpl(
+    private val connectionFactory: ((Request) -> HttpURLConnection)? = null,
+): VCL {
     companion object {
         val TAG = VCLImpl::class.simpleName
 
@@ -88,47 +92,54 @@ internal class VCLImpl: VCL {
 
     @Throws
     private fun initializeUseCases(context: Context) {
-        authTokenUseCase = VclBlocksProvider.provideAuthTokenUseCase()
+        authTokenUseCase = VclBlocksProvider.provideAuthTokenUseCase(connectionFactory)
         presentationRequestUseCase =
             VclBlocksProvider.providePresentationRequestUseCase(
                 context,
-                initializationDescriptor.cryptoServicesDescriptor
+                initializationDescriptor.cryptoServicesDescriptor,
+                connectionFactory
             )
         presentationSubmissionUseCase = VclBlocksProvider.providePresentationSubmissionUseCase(
             context,
-            initializationDescriptor.cryptoServicesDescriptor
+            initializationDescriptor.cryptoServicesDescriptor,
+            connectionFactory
         )
-        exchangeProgressUseCase = VclBlocksProvider.provideExchangeProgressUseCase()
-        organizationsUseCase = VclBlocksProvider.provideOrganizationsUseCase()
+        exchangeProgressUseCase = VclBlocksProvider.provideExchangeProgressUseCase(connectionFactory)
+        organizationsUseCase = VclBlocksProvider.provideOrganizationsUseCase(connectionFactory)
         credentialManifestUseCase =
             VclBlocksProvider.provideCredentialManifestUseCase(
                 context,
-                initializationDescriptor.cryptoServicesDescriptor
+                initializationDescriptor.cryptoServicesDescriptor,
+                connectionFactory
             )
         identificationSubmissionUseCase = VclBlocksProvider.provideIdentificationSubmissionUseCase(
             context,
-            initializationDescriptor.cryptoServicesDescriptor
+            initializationDescriptor.cryptoServicesDescriptor,
+            connectionFactory
         )
-        generateOffersUseCase = VclBlocksProvider.provideGenerateOffersUseCase()
+        generateOffersUseCase = VclBlocksProvider.provideGenerateOffersUseCase(connectionFactory)
         finalizeOffersUseCase =
             VclBlocksProvider.provideFinalizeOffersUseCase(
                 context,
                 credentialTypesModel,
                 initializationDescriptor.cryptoServicesDescriptor,
-                initializationDescriptor.isDirectIssuerCheckOn
+                initializationDescriptor.isDirectIssuerCheckOn,
+                connectionFactory
             )
         credentialTypesUIFormSchemaUseCase =
-            VclBlocksProvider.provideCredentialTypesUIFormSchemaUseCase()
-        verifiedProfileUseCase = VclBlocksProvider.provideVerifiedProfileUseCase()
+            VclBlocksProvider.provideCredentialTypesUIFormSchemaUseCase(connectionFactory)
+        verifiedProfileUseCase = VclBlocksProvider.provideVerifiedProfileUseCase(connectionFactory)
         jwtServiceUseCase =
             VclBlocksProvider.provideJwtServiceUseCase(
                 context,
-                initializationDescriptor.cryptoServicesDescriptor
+                initializationDescriptor.cryptoServicesDescriptor,
+                connectionFactory
             )
         keyServiceUseCase =
             VclBlocksProvider.provideKeyServiceUseCase(
                 context,
-                initializationDescriptor.cryptoServicesDescriptor
+                initializationDescriptor.cryptoServicesDescriptor,
+                connectionFactory
             )
     }
 
@@ -161,9 +172,9 @@ internal class VCLImpl: VCL {
         errorHandler: (VCLError) -> Unit
     ) {
         credentialTypesModel =
-            VclBlocksProvider.provideCredentialTypesModel(context)
+            VclBlocksProvider.provideCredentialTypesModel(context, connectionFactory)
         countriesModel =
-            VclBlocksProvider.provideCountriesModel(context)
+            VclBlocksProvider.provideCountriesModel(context, connectionFactory)
 
         countriesModel.initialize(cacheSequence) { result ->
             result.handleResult(
@@ -186,7 +197,8 @@ internal class VCLImpl: VCL {
                             credentialTypeSchemasModel =
                                 VclBlocksProvider.provideCredentialTypeSchemasModel(
                                     context,
-                                    credentialTypes
+                                    credentialTypes,
+                                    connectionFactory
                                 )
                             credentialTypeSchemasModel.initialize(cacheSequence) { result ->
                                 result.handleResult(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/VclBlocksProvider.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/VclBlocksProvider.kt
@@ -17,6 +17,7 @@ import io.velocitycareerlabs.impl.data.verifiers.CredentialDidVerifierImpl
 import io.velocitycareerlabs.impl.data.infrastructure.db.CacheServiceImpl
 import io.velocitycareerlabs.impl.data.infrastructure.db.SecretStoreServiceImpl
 import io.velocitycareerlabs.impl.data.infrastructure.network.NetworkServiceImpl
+import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.impl.data.infrastructure.executors.ExecutorImpl
 import io.velocitycareerlabs.impl.keys.VCLKeyServiceLocalImpl
 import io.velocitycareerlabs.impl.data.models.*
@@ -40,12 +41,18 @@ import io.velocitycareerlabs.impl.jwt.local.VCLJwtVerifyServiceLocalImpl
 import io.velocitycareerlabs.impl.jwt.remote.VCLJwtSignServiceRemoteImpl
 import io.velocitycareerlabs.impl.jwt.remote.VCLJwtVerifyServiceRemoteImpl
 import io.velocitycareerlabs.impl.keys.VCLKeyServiceRemoteImpl
+import java.net.HttpURLConnection
 
 internal object VclBlocksProvider {
+        private fun networkService(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ) = NetworkServiceImpl(connectionFactory)
+
         @Throws(VCLError::class)
         internal fun chooseKeyService(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): VCLKeyService {
                 when (cryptoServicesDescriptor.cryptoServiceType) {
                         VCLCryptoServiceType.Local -> return VCLKeyServiceLocalImpl(
@@ -57,7 +64,7 @@ internal object VclBlocksProvider {
                         VCLCryptoServiceType.Remote -> {
                                 cryptoServicesDescriptor.remoteCryptoServicesUrlsDescriptor?.keyServiceUrls?.let { keyServiceUrls ->
                                         return VCLKeyServiceRemoteImpl(
-                                                NetworkServiceImpl(),
+                                                networkService(connectionFactory),
                                                 keyServiceUrls
                                         )
                                 }
@@ -73,19 +80,21 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         internal fun chooseJwtSignService(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): VCLJwtSignService {
                 when (cryptoServicesDescriptor.cryptoServiceType) {
                         VCLCryptoServiceType.Local -> return VCLJwtSignServiceLocalImpl(
                                 chooseKeyService(
                                         context,
-                                        cryptoServicesDescriptor
+                                        cryptoServicesDescriptor,
+                                        connectionFactory
                                 )
                         )
 
                         VCLCryptoServiceType.Remote -> cryptoServicesDescriptor.remoteCryptoServicesUrlsDescriptor?.jwtServiceUrls?.jwtSignServiceUrl?.let { jwtSignServiceUrl ->
                                 return VCLJwtSignServiceRemoteImpl(
-                                        NetworkServiceImpl(),
+                                        networkService(connectionFactory),
                                         jwtSignServiceUrl
                                 )
                         }
@@ -98,14 +107,15 @@ internal object VclBlocksProvider {
         }
 
         internal fun chooseJwtVerifyService(
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): VCLJwtVerifyService {
                 when (cryptoServicesDescriptor.cryptoServiceType) {
                         VCLCryptoServiceType.Local -> return VCLJwtVerifyServiceLocalImpl()
 
                         VCLCryptoServiceType.Remote -> cryptoServicesDescriptor.remoteCryptoServicesUrlsDescriptor?.jwtServiceUrls?.jwtVerifyServiceUrl?.let { jwtVerifyServiceUrl ->
                                 return VCLJwtVerifyServiceRemoteImpl(
-                                        NetworkServiceImpl(),
+                                        networkService(connectionFactory),
                                         jwtVerifyServiceUrl
                                 )
                         }
@@ -121,12 +131,13 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun provideCredentialTypeSchemasModel(
                 context: Context,
-                credentialTypes: VCLCredentialTypes
+                credentialTypes: VCLCredentialTypes,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): CredentialTypeSchemasModel =
                 CredentialTypeSchemasModelImpl(
                         CredentialTypeSchemasUseCaseImpl(
                                 CredentialTypeSchemaRepositoryImpl(
-                                        NetworkServiceImpl(),
+                                        networkService(connectionFactory),
                                         CacheServiceImpl(context)
                                 ),
                                 credentialTypes,
@@ -135,11 +146,14 @@ internal object VclBlocksProvider {
                 )
 
         @Throws(VCLError::class)
-        fun provideCredentialTypesModel(context: Context): CredentialTypesModel =
+        fun provideCredentialTypesModel(
+                context: Context,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): CredentialTypesModel =
                 CredentialTypesModelImpl(
                         CredentialTypesUseCaseImpl(
                                 CredentialTypesRepositoryImpl(
-                                        NetworkServiceImpl(),
+                                        networkService(connectionFactory),
                                         CacheServiceImpl(context)
                                 ),
                                 ExecutorImpl.instance
@@ -147,11 +161,14 @@ internal object VclBlocksProvider {
                 )
 
         @Throws(VCLError::class)
-        fun provideCountriesModel(context: Context): CountriesModel =
+        fun provideCountriesModel(
+                context: Context,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): CountriesModel =
                 CountriesModelImpl(
                         CountriesUseCaseImpl(
                                 CountriesRepositoryImpl(
-                                        NetworkServiceImpl(),
+                                        networkService(connectionFactory),
                                         CacheServiceImpl(context)
                                 ),
                                 ExecutorImpl.instance
@@ -161,18 +178,19 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun providePresentationRequestUseCase(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): PresentationRequestUseCase =
                 PresentationRequestUseCaseImpl(
                         PresentationRequestRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         ResolveDidDocumentRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         JwtServiceRepositoryImpl(
-                                chooseJwtSignService(context, cryptoServicesDescriptor),
-                                chooseJwtVerifyService(cryptoServicesDescriptor)
+                                chooseJwtSignService(context, cryptoServicesDescriptor, connectionFactory),
+                                chooseJwtVerifyService(cryptoServicesDescriptor, connectionFactory)
                         ),
                         PresentationRequestByDeepLinkVerifierImpl(),
                         ExecutorImpl.instance
@@ -181,23 +199,26 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun providePresentationSubmissionUseCase(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): PresentationSubmissionUseCase =
                 PresentationSubmissionUseCaseImpl(
                         PresentationSubmissionRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         JwtServiceRepositoryImpl(
-                                chooseJwtSignService(context, cryptoServicesDescriptor),
-                                chooseJwtVerifyService(cryptoServicesDescriptor)
+                                chooseJwtSignService(context, cryptoServicesDescriptor, connectionFactory),
+                                chooseJwtVerifyService(cryptoServicesDescriptor, connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
 
-        fun provideOrganizationsUseCase(): OrganizationsUseCase =
+        fun provideOrganizationsUseCase(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): OrganizationsUseCase =
                 OrganizationsUseCaseImpl(
                         OrganizationsRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
@@ -205,18 +226,19 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun provideCredentialManifestUseCase(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): CredentialManifestUseCase =
                 CredentialManifestUseCaseImpl(
                         CredentialManifestRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         ResolveDidDocumentRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         JwtServiceRepositoryImpl(
-                                chooseJwtSignService(context, cryptoServicesDescriptor),
-                                chooseJwtVerifyService(cryptoServicesDescriptor)
+                                chooseJwtSignService(context, cryptoServicesDescriptor, connectionFactory),
+                                chooseJwtVerifyService(cryptoServicesDescriptor, connectionFactory)
                         ),
                         CredentialManifestByDeepLinkVerifierImpl(),
                         ExecutorImpl.instance
@@ -225,35 +247,40 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun provideIdentificationSubmissionUseCase(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): IdentificationSubmissionUseCase =
                 IdentificationSubmissionUseCaseImpl(
                         IdentificationSubmissionRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         JwtServiceRepositoryImpl(
-                                chooseJwtSignService(context, cryptoServicesDescriptor),
-                                chooseJwtVerifyService(cryptoServicesDescriptor)
+                                chooseJwtSignService(context, cryptoServicesDescriptor, connectionFactory),
+                                chooseJwtVerifyService(cryptoServicesDescriptor, connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
 
-        fun provideExchangeProgressUseCase(): ExchangeProgressUseCase =
+        fun provideExchangeProgressUseCase(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): ExchangeProgressUseCase =
                 ExchangeProgressUseCaseImpl(
                         ExchangeProgressRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
 
-        fun provideGenerateOffersUseCase(): GenerateOffersUseCase =
+        fun provideGenerateOffersUseCase(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): GenerateOffersUseCase =
                 GenerateOffersUseCaseImpl(
                         GenerateOffersRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         OffersByDeepLinkVerifierImpl(
                                 ResolveDidDocumentRepositoryImpl(
-                                        NetworkServiceImpl()
+                                        networkService(connectionFactory)
                                 )
                         ),
                         ExecutorImpl.instance
@@ -264,7 +291,8 @@ internal object VclBlocksProvider {
                 context: Context,
                 credentialTypesModel: CredentialTypesModel,
                 cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
-                isDirectIssuerCheckOn: Boolean
+                isDirectIssuerCheckOn: Boolean,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): FinalizeOffersUseCase {
                 var credentialIssuerVerifier: CredentialIssuerVerifier =
                         CredentialIssuerVerifierEmptyImpl()
@@ -272,23 +300,23 @@ internal object VclBlocksProvider {
                         credentialIssuerVerifier = CredentialIssuerVerifierImpl(
                                 credentialTypesModel,
                                 CredentialSubjectContextRepositoryImpl(
-                                        NetworkServiceImpl()
+                                        networkService(connectionFactory)
                                 )
                         )
                 }
                 return FinalizeOffersUseCaseImpl(
                         FinalizeOffersRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         JwtServiceRepositoryImpl(
-                                chooseJwtSignService(context, cryptoServicesDescriptor),
-                                chooseJwtVerifyService(cryptoServicesDescriptor)
+                                chooseJwtSignService(context, cryptoServicesDescriptor, connectionFactory),
+                                chooseJwtVerifyService(cryptoServicesDescriptor, connectionFactory)
                         ),
                         credentialIssuerVerifier,
                         CredentialDidVerifierImpl(),
                         CredentialsByDeepLinkVerifierImpl(
                                 ResolveDidDocumentRepositoryImpl(
-                                        NetworkServiceImpl()
+                                        networkService(connectionFactory)
                                 )
                         ),
                         ExecutorImpl.instance
@@ -296,24 +324,30 @@ internal object VclBlocksProvider {
         }
 
         @Throws(VCLError::class)
-        fun provideAuthTokenUseCase(): AuthTokenUseCase =
+        fun provideAuthTokenUseCase(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): AuthTokenUseCase =
                 AuthTokenUseCaseImpl(
-                        AuthTokenRepositoryImpl(NetworkServiceImpl()),
+                        AuthTokenRepositoryImpl(networkService(connectionFactory)),
                         ExecutorImpl.instance
                 )
 
-        fun provideCredentialTypesUIFormSchemaUseCase(): CredentialTypesUIFormSchemaUseCase =
+        fun provideCredentialTypesUIFormSchemaUseCase(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): CredentialTypesUIFormSchemaUseCase =
                 CredentialTypesUIFormSchemaUseCaseImpl(
                         CredentialTypesUIFormSchemaRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
 
-        fun provideVerifiedProfileUseCase(): VerifiedProfileUseCase =
+        fun provideVerifiedProfileUseCase(
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
+        ): VerifiedProfileUseCase =
                 VerifiedProfileUseCaseImpl(
                         VerifiedProfileRepositoryImpl(
-                                NetworkServiceImpl()
+                                networkService(connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
@@ -321,12 +355,13 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun provideJwtServiceUseCase(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): JwtServiceUseCase =
                 JwtServiceUseCaseImpl(
                         JwtServiceRepositoryImpl(
-                                chooseJwtSignService(context, cryptoServicesDescriptor),
-                                chooseJwtVerifyService(cryptoServicesDescriptor)
+                                chooseJwtSignService(context, cryptoServicesDescriptor, connectionFactory),
+                                chooseJwtVerifyService(cryptoServicesDescriptor, connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )
@@ -334,11 +369,12 @@ internal object VclBlocksProvider {
         @Throws(VCLError::class)
         fun provideKeyServiceUseCase(
                 context: Context,
-                cryptoServicesDescriptor: VCLCryptoServicesDescriptor
+                cryptoServicesDescriptor: VCLCryptoServicesDescriptor,
+                connectionFactory: ((Request) -> HttpURLConnection)? = null
         ): KeyServiceUseCase =
                 KeyServiceUseCaseImpl(
                         KeyServiceRepositoryImpl(
-                                chooseKeyService(context, cryptoServicesDescriptor)
+                                chooseKeyService(context, cryptoServicesDescriptor, connectionFactory)
                         ),
                         ExecutorImpl.instance
                 )

--- a/VCL/src/test/java/io/velocitycareerlabs/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
@@ -53,6 +53,7 @@ import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
 import java.net.UnknownHostException
+import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -656,7 +657,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
         private val didDocumentStatusCode: Int = 200,
         private val didDocumentContentType: String? = Request.ContentTypeApplicationJson,
     ) {
-        val requestedEndpoints = mutableListOf<String>()
+        val requestedEndpoints: MutableList<String> = Collections.synchronizedList(mutableListOf())
 
         fun connectionFor(request: Request): HttpURLConnection {
             requestedEndpoints.add(request.endpoint)

--- a/VCL/src/test/java/io/velocitycareerlabs/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/backwardscompatibility/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
@@ -1,0 +1,742 @@
+/**
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.velocitycareerlabs.backwardscompatibility
+
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import io.velocitycareerlabs.api.VCLCryptoServiceType
+import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByDeepLink
+import io.velocitycareerlabs.api.entities.VCLDeepLink
+import io.velocitycareerlabs.api.entities.VCLDidJwk
+import io.velocitycareerlabs.api.entities.VCLJwt
+import io.velocitycareerlabs.api.entities.VCLPresentationRequestDescriptor
+import io.velocitycareerlabs.api.entities.VCLPublicJwk
+import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.VCLToken
+import io.velocitycareerlabs.api.entities.error.VCLError
+import io.velocitycareerlabs.api.entities.error.VCLErrorCode
+import io.velocitycareerlabs.api.entities.error.VCLStatusCode
+import io.velocitycareerlabs.api.entities.initialization.VCLCryptoServicesDescriptor
+import io.velocitycareerlabs.api.entities.initialization.VCLInjectedCryptoServicesDescriptor
+import io.velocitycareerlabs.api.entities.initialization.VCLInitializationDescriptor
+import io.velocitycareerlabs.api.jwt.VCLJwtVerifyService
+import io.velocitycareerlabs.impl.VCLImpl
+import io.velocitycareerlabs.impl.data.infrastructure.network.Request
+import io.velocitycareerlabs.infrastructure.resources.valid.CountriesMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialManifestMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypeSchemaMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypesMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.DeepLinkMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.DidDocumentMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.DidJwkMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.PresentationRequestMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.VCLJwtSignServiceMock
+import io.velocitycareerlabs.infrastructure.resources.valid.VCLKeyServiceMock
+import io.velocitycareerlabs.infrastructure.resources.valid.VerifiedProfileMocks
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.MalformedURLException
+import java.net.URL
+import java.net.UnknownHostException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
+    // Link validation -> invalid_link
+
+    @Test
+    fun malformedLinksAndMissingRequiredParamsReturnSdkError() {
+        entryPoints.forEach { entryPoint ->
+            val missingDidDeepLink = VCLDeepLink("velocity-network://${entryPoint.schemePath}")
+
+            listOf(VCLDeepLink("not a url"), missingDidDeepLink).forEach { deepLink ->
+                val error = getEntryPointError(entryPoint, deepLink)
+
+                assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+                assertTrue(error.message!!.contains("did was not found"))
+            }
+        }
+    }
+
+    @Test
+    fun unsupportedSchemeWithKnownQueryParamsReturnsNullEndpointSdkError() {
+        entryPoints.forEach { entryPoint ->
+            val deepLink = VCLDeepLink(
+                "https://example.com/${entryPoint.schemePath}?${entryPoint.didParam}=did:example:entity"
+            )
+            val error = getEntryPointError(entryPoint, deepLink)
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(entryPoint.endpointNullMessage, error.message)
+        }
+    }
+
+    @Test
+    fun undecodableQueryParamsThrowBeforeSdkEntryPoint() {
+        listOf(
+            "velocity-network://issue?request_uri=%",
+            "velocity-network://inspect?request_uri=%",
+        ).forEach { deepLinkValue ->
+            try {
+                VCLDeepLink(deepLinkValue)
+                fail("Invalid URL encoding should throw")
+            } catch (error: IllegalArgumentException) {
+                assertTrue(error.message!!.contains("URLDecoder"))
+            }
+        }
+    }
+
+    @Test
+    fun missingRequestUriProducesEndpointNullSdkErrors() {
+        entryPoints.forEach { entryPoint ->
+            val deepLink = VCLDeepLink(
+                "velocity-network://${entryPoint.schemePath}?${entryPoint.didParam}=did:example:entity"
+            )
+            val error = getEntryPointError(entryPoint, deepLink)
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(entryPoint.endpointNullMessage, error.message)
+        }
+    }
+
+    @Test
+    fun malformedAndDisallowedRequestUriValuesReachTransportAsRawEndpointText() {
+        entryPoints.forEach { entryPoint ->
+            val malformedRequestUriDeepLink = VCLDeepLink(
+                "velocity-network://${entryPoint.schemePath}?request_uri=not-a-url" +
+                    "&${entryPoint.didParam}=did:example:entity"
+            )
+            val disallowedSchemeDeepLink = VCLDeepLink(
+                "velocity-network://${entryPoint.schemePath}?" +
+                    "request_uri=ftp%3A%2F%2Fexample.com%2Frequest" +
+                    "&${entryPoint.didParam}=did:example:entity"
+            )
+            val malformedRequestUri = getEntryPointError(entryPoint, malformedRequestUriDeepLink)
+            val disallowedSchemeRequestUri = getEntryPointError(entryPoint, disallowedSchemeDeepLink)
+
+            assertEquals(VCLErrorCode.SdkError.value, malformedRequestUri.errorCode)
+            assertTrue(malformedRequestUri.message!!.contains("no protocol: not-a-url"))
+            assertEquals(VCLErrorCode.SdkError.value, disallowedSchemeRequestUri.errorCode)
+            assertTrue(disallowedSchemeRequestUri.message!!.contains("unknown protocol: ftp"))
+        }
+    }
+
+    // Client request fetch -> client_request_unauthorized / client_request_rejected
+
+    @Test
+    fun transportFailureReturnsSdkErrorWithNetworkStatusOnly() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    requestFailure = UnknownHostException("offline"),
+                ),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(VCLStatusCode.NetworkError.value, error.statusCode)
+            assertTrue(error.message!!.contains("offline"))
+        }
+    }
+
+    @Test
+    fun requestEndpoint401And403PreserveHttpStatusAndPayloadErrorCode() {
+        entryPoints.forEach { entryPoint ->
+            listOf(401, 403).forEach { statusCode ->
+                val error = getEntryPointError(
+                    entryPoint,
+                    router = defaultRouter(entryPoint).copy(
+                        requestStatusCode = statusCode,
+                        requestPayload = ErrorMocks.Payload,
+                        requestContentType = Request.ContentTypeApplicationJson,
+                    ),
+                )
+
+                assertEquals(ErrorMocks.ErrorCode, error.errorCode)
+                assertEquals(ErrorMocks.RequestId, error.requestId)
+                assertEquals(ErrorMocks.Message, error.message)
+                assertEquals(ErrorMocks.StatusCode, error.statusCode)
+            }
+        }
+    }
+
+    @Test
+    fun requestEndpointRejectionsPreserveHttpStatusWhenPayloadHasNoStatusCode() {
+        val payloadWithoutStatusCode = JSONObject(ErrorMocks.Payload).apply {
+            remove(VCLError.KeyStatusCode)
+        }.toString()
+
+        entryPoints.forEach { entryPoint ->
+            listOf(400, 404, 409, 410, 422, 500, 502).forEach { statusCode ->
+                val error = getEntryPointError(
+                    entryPoint,
+                    router = defaultRouter(entryPoint).copy(
+                        requestStatusCode = statusCode,
+                        requestPayload = payloadWithoutStatusCode,
+                        requestContentType = Request.ContentTypeApplicationJson,
+                    ),
+                )
+
+                assertEquals(ErrorMocks.ErrorCode, error.errorCode)
+                assertEquals(statusCode, error.statusCode)
+            }
+        }
+    }
+
+    @Test
+    fun plainTextRequestEndpointRejectionsDefaultToSdkErrorWithHttpStatusAndPayloadMessage() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    requestStatusCode = 500,
+                    requestPayload = "plain text failure",
+                    requestContentType = "text/plain",
+                ),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(500, error.statusCode)
+            assertEquals("plain text failure", error.message)
+            assertEquals("plain text failure", error.payload)
+        }
+    }
+
+    @Test
+    fun jsonRequestEndpointRejectionsWithoutErrorCodeDefaultToSdkError() {
+        val payloadWithoutErrorCode = JSONObject(ErrorMocks.Payload).apply {
+            remove(VCLError.KeyErrorCode)
+        }.toString()
+
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    requestStatusCode = 422,
+                    requestPayload = payloadWithoutErrorCode,
+                    requestContentType = Request.ContentTypeApplicationJson,
+                ),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(ErrorMocks.RequestId, error.requestId)
+            assertEquals(ErrorMocks.Message, error.message)
+            assertEquals(ErrorMocks.StatusCode, error.statusCode)
+        }
+    }
+
+    @Test
+    fun emptyRequestEndpointResponseReturnsSdkError() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(requestPayload = ""),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+        }
+    }
+
+    @Test
+    fun malformedRequestEndpointResponseReturnsSdkError() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(requestPayload = "not json"),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+        }
+    }
+
+    @Test
+    fun missingExpectedRequestFieldsReturnSdkErrorAfterEmptyJwtIsDecoded() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(requestPayload = "{}"),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+        }
+    }
+
+    // DID resolution -> issuer_did_unresolvable / verifier_did_unresolvable
+
+    @Test
+    fun didResolutionNetworkFailurePropagatesSdkErrorAndStatusFromNetwork() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    didDocumentStatusCode = 404,
+                    didDocumentPayload = """{"message":"resolve failed","errorCode":"sdk_error"}""",
+                    didDocumentContentType = Request.ContentTypeApplicationJson,
+                ),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(404, error.statusCode)
+            assertEquals("resolve failed", error.message)
+        }
+    }
+
+    @Test
+    fun invalidDidDocumentShapeReturnsSdkErrorAtRequestValidation() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(didDocumentPayload = "not json"),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertTrue(error.message!!.contains("public jwk not found for kid"))
+        }
+    }
+
+    @Test
+    fun missingDidDocumentVerificationMaterialReturnsSdkError() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(didDocumentPayload = "{}"),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertTrue(error.message!!.contains("public jwk not found for kid"))
+        }
+    }
+
+    // Registration / profile check -> issuer_not_registered / verifier_not_registered
+
+    @Test
+    fun verifiedProfileLookupFailurePropagatesNetworkErrorDetails() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    verifiedProfileStatusCode = 404,
+                    verifiedProfilePayload = """{"message":"profile missing","errorCode":"sdk_error"}""",
+                    verifiedProfileContentType = Request.ContentTypeApplicationJson,
+                ),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(404, error.statusCode)
+            assertEquals("profile missing", error.message)
+        }
+    }
+
+    // Request authorization -> issuer_request_unauthorized / verifier_request_unauthorized
+
+    @Test
+    fun emptyVerifiedProfileFailsServiceTypeVerification() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(verifiedProfilePayload = "{}"),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(VCLStatusCode.VerificationError.value, error.statusCode)
+            assertTrue(error.message!!.contains("Wrong service type"))
+        }
+    }
+
+    @Test
+    fun wrongIssuerOrVerifierServiceTypeReturnsSdkErrorWithVerificationStatus() {
+        entryPoints.forEach { entryPoint ->
+            val wrongServiceProfile = when (entryPoint) {
+                EntryPoint.Issuing -> VerifiedProfileMocks.VerifiedProfileInspectorJsonStr
+                EntryPoint.Presentation -> VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1
+            }
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(verifiedProfilePayload = wrongServiceProfile),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals(VCLStatusCode.VerificationError.value, error.statusCode)
+            assertTrue(error.message!!.contains("Wrong service type"))
+        }
+    }
+
+    // Request validation -> issuer_request_invalid / verifier_request_invalid
+
+    @Test
+    fun duplicateQueryParamsUseLastDidValueAtSdkEntryPoint() {
+        entryPoints.forEach { entryPoint ->
+            val router = defaultRouter(entryPoint)
+            val vcl = initializedVcl(router)
+            val deepLink = VCLDeepLink(
+                "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
+                    "&${entryPoint.didParam}=did:example:first&${entryPoint.didParam}=${entryPoint.lastDid}"
+            )
+            val error = when (entryPoint) {
+                EntryPoint.Issuing -> awaitCredentialManifestError(
+                    vcl,
+                    credentialManifestDescriptor(deepLink),
+                )
+                EntryPoint.Presentation -> awaitPresentationRequestError(
+                    vcl,
+                    presentationDescriptor(deepLink),
+                )
+            }
+
+            assertEquals(entryPoint.mismatchErrorCode, error.errorCode)
+            assertTrue(router.requestedEndpoints.any { it.contains(entryPoint.lastDid) })
+        }
+    }
+
+    @Test
+    fun malformedDidSyntaxIsAcceptedUntilRequestValidation() {
+        entryPoints.forEach { entryPoint ->
+            val deepLink = VCLDeepLink(
+                "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
+                    "&${entryPoint.didParam}=not-a-did"
+            )
+            val error = getEntryPointError(entryPoint, deepLink)
+
+            assertEquals(entryPoint.mismatchErrorCode, error.errorCode)
+        }
+    }
+
+    @Test
+    fun requestValidationFailuresUseLegacyMismatchErrorCodes() {
+        entryPoints.forEach { entryPoint ->
+            val deepLink = VCLDeepLink(
+                "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
+                    "&${entryPoint.didParam}=did:example:wrong"
+            )
+            val error = getEntryPointError(entryPoint, deepLink)
+
+            assertEquals(entryPoint.mismatchErrorCode, error.errorCode)
+        }
+    }
+
+    @Test
+    fun jwtVerificationFailurePropagatesSdkErrorFromInjectedJwtService() {
+        val expectedError = VCLError(
+            errorCode = VCLErrorCode.SdkError.value,
+            message = "jwt signature verification failed",
+        )
+
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                jwtVerificationResult = VCLResult.Failure(expectedError),
+            )
+
+            assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
+            assertEquals("jwt signature verification failed", error.message)
+        }
+    }
+
+    private enum class EntryPoint {
+        Issuing,
+        Presentation,
+    }
+
+    private val entryPoints = listOf(EntryPoint.Issuing, EntryPoint.Presentation)
+
+    private val EntryPoint.defaultDeepLink: VCLDeepLink
+        get() = when (this) {
+            EntryPoint.Issuing -> DeepLinkMocks.CredentialManifestDeepLinkDevNet
+            EntryPoint.Presentation -> DeepLinkMocks.PresentationRequestDeepLinkDevNet
+        }
+
+    private val EntryPoint.endpointNullMessage: String
+        get() = when (this) {
+            EntryPoint.Issuing -> "credentialManifestDescriptor.endpoint = null"
+            EntryPoint.Presentation -> "presentationRequestDescriptor.endpoint = null"
+        }
+
+    private val EntryPoint.mismatchErrorCode: String
+        get() = when (this) {
+            EntryPoint.Issuing -> VCLErrorCode.MismatchedRequestIssuerDid.value
+            EntryPoint.Presentation -> VCLErrorCode.MismatchedPresentationRequestInspectorDid.value
+        }
+
+    private val EntryPoint.didParam: String
+        get() = when (this) {
+            EntryPoint.Issuing -> "issuerDid"
+            EntryPoint.Presentation -> "inspectorDid"
+        }
+
+    private val EntryPoint.schemePath: String
+        get() = when (this) {
+            EntryPoint.Issuing -> "issue"
+            EntryPoint.Presentation -> "inspect"
+        }
+
+    private val EntryPoint.encodedRequestUri: String
+        get() = when (this) {
+            EntryPoint.Issuing -> DeepLinkMocks.CredentialManifestRequestUriStr
+            EntryPoint.Presentation -> DeepLinkMocks.PresentationRequestRequestUriStr
+        }
+
+    private val EntryPoint.lastDid: String get() = "did:example:last"
+
+    private fun defaultRouter(entryPoint: EntryPoint): BaselineHttpRouter =
+        when (entryPoint) {
+            EntryPoint.Issuing -> BaselineHttpRouter()
+            EntryPoint.Presentation -> BaselineHttpRouter(
+                verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
+                requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
+            )
+        }
+
+    private fun getEntryPointError(
+        entryPoint: EntryPoint,
+        deepLink: VCLDeepLink = entryPoint.defaultDeepLink,
+        router: BaselineHttpRouter = defaultRouter(entryPoint),
+        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    ): VCLError =
+        when (entryPoint) {
+            EntryPoint.Issuing -> getCredentialManifestError(deepLink, router, jwtVerificationResult)
+            EntryPoint.Presentation -> getPresentationRequestError(deepLink, router, jwtVerificationResult)
+        }
+
+    private fun getCredentialManifestError(
+        deepLink: VCLDeepLink,
+        router: BaselineHttpRouter = BaselineHttpRouter(),
+        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    ): VCLError {
+        val vcl = initializedVcl(router, jwtVerificationResult)
+        return awaitCredentialManifestError(vcl, credentialManifestDescriptor(deepLink))
+    }
+
+    private fun getPresentationRequestError(
+        deepLink: VCLDeepLink,
+        router: BaselineHttpRouter = BaselineHttpRouter(
+            verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
+            requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
+        ),
+        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    ): VCLError {
+        val vcl = initializedVcl(router, jwtVerificationResult)
+        return awaitPresentationRequestError(vcl, presentationDescriptor(deepLink))
+    }
+
+    private fun initializedVcl(
+        router: BaselineHttpRouter,
+        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    ): VCLImpl {
+        val vcl = VCLImpl(router::connectionFor)
+        var initError: VCLError? = null
+        val latch = CountDownLatch(1)
+        vcl.initialize(
+            context = ApplicationProvider.getApplicationContext(),
+            initializationDescriptor = VCLInitializationDescriptor(
+                cacheSequence = cacheSequence.incrementAndGet(),
+                cryptoServicesDescriptor = VCLCryptoServicesDescriptor(
+                    cryptoServiceType = VCLCryptoServiceType.Injected,
+                    injectedCryptoServicesDescriptor = VCLInjectedCryptoServicesDescriptor(
+                        keyService = VCLKeyServiceMock(),
+                        jwtSignService = VCLJwtSignServiceMock(),
+                        jwtVerifyService = FixedJwtVerifyService(jwtVerificationResult),
+                    ),
+                ),
+            ),
+            successHandler = {
+                latch.countDown()
+            },
+            errorHandler = {
+                initError = it
+                latch.countDown()
+            },
+        )
+        drainMainThreadUntil(latch)
+        assertNull("VCL initialization failed: ${initError?.toJsonObject()}", initError)
+        return vcl
+    }
+
+    private fun awaitCredentialManifestError(
+        vcl: VCLImpl,
+        descriptor: VCLCredentialManifestDescriptorByDeepLink,
+    ): VCLError {
+        var result: VCLError? = null
+        val latch = CountDownLatch(1)
+        vcl.getCredentialManifest(
+            credentialManifestDescriptor = descriptor,
+            successHandler = { manifest ->
+                fail("Credential manifest failure expected: $manifest")
+            },
+            errorHandler = {
+                result = it
+                latch.countDown()
+            },
+        )
+        drainMainThreadUntil(latch)
+        return result ?: error("getCredentialManifest did not invoke errorHandler")
+    }
+
+    private fun awaitPresentationRequestError(
+        vcl: VCLImpl,
+        descriptor: VCLPresentationRequestDescriptor,
+    ): VCLError {
+        var result: VCLError? = null
+        val latch = CountDownLatch(1)
+        vcl.getPresentationRequest(
+            presentationRequestDescriptor = descriptor,
+            successHandler = { presentationRequest ->
+                fail("Presentation request failure expected: $presentationRequest")
+            },
+            errorHandler = {
+                result = it
+                latch.countDown()
+            },
+        )
+        drainMainThreadUntil(latch)
+        return result ?: error("getPresentationRequest did not invoke errorHandler")
+    }
+
+    private fun drainMainThreadUntil(latch: CountDownLatch) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (latch.count > 0 && System.currentTimeMillis() < deadline) {
+            shadowOf(android.os.Looper.getMainLooper()).idle()
+            latch.await(20, TimeUnit.MILLISECONDS)
+        }
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+        assertEquals("Timed out waiting for callback", 0, latch.count)
+    }
+
+    private fun credentialManifestDescriptor(deepLink: VCLDeepLink) =
+        VCLCredentialManifestDescriptorByDeepLink(
+            deepLink = deepLink,
+            didJwk = DidJwkMocks.DidJwk,
+        )
+
+    private fun presentationDescriptor(deepLink: VCLDeepLink) =
+        VCLPresentationRequestDescriptor(
+            deepLink = deepLink,
+            didJwk = DidJwkMocks.DidJwk,
+        )
+
+    private class FixedJwtVerifyService(
+        private val result: VCLResult<Boolean>,
+    ) : VCLJwtVerifyService {
+        override fun verify(
+            jwt: VCLJwt,
+            publicJwk: VCLPublicJwk,
+            remoteCryptoServicesToken: VCLToken?,
+            completionBlock: (VCLResult<Boolean>) -> Unit,
+        ) {
+            completionBlock(result)
+        }
+    }
+
+    private data class BaselineHttpRouter(
+        private val verifiedProfilePayload: String = VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1,
+        private val verifiedProfileStatusCode: Int = 200,
+        private val verifiedProfileContentType: String? = Request.ContentTypeApplicationJson,
+        private val requestPayload: String = CredentialManifestMocks.CredentialManifest1,
+        private val requestStatusCode: Int = 200,
+        private val requestContentType: String? = Request.ContentTypeApplicationJson,
+        private val requestFailure: Exception? = null,
+        private val didDocumentPayload: String = DidDocumentMocks.DidDocumentMockStr,
+        private val didDocumentStatusCode: Int = 200,
+        private val didDocumentContentType: String? = Request.ContentTypeApplicationJson,
+    ) {
+        val requestedEndpoints = mutableListOf<String>()
+
+        fun connectionFor(request: Request): HttpURLConnection {
+            requestedEndpoints.add(request.endpoint)
+            if (isSdkRequestEndpoint(request.endpoint)) {
+                requestFailure?.let { throw it }
+                if (request.endpoint.startsWith("not-a-url")) {
+                    throw MalformedURLException("no protocol: ${request.endpoint}")
+                }
+                if (request.endpoint.startsWith("ftp://")) {
+                    throw MalformedURLException("unknown protocol: ftp")
+                }
+            }
+            val route = routeFor(request.endpoint)
+            return FakeHttpURLConnection(
+                url = URL(request.endpoint),
+                responseCodeValue = route.statusCode,
+                contentTypeValue = route.contentType,
+                payload = route.payload,
+            )
+        }
+
+        private fun routeFor(endpoint: String): Route =
+            when {
+                endpoint.contains("/reference/countries") ->
+                    Route(200, Request.ContentTypeApplicationJson, CountriesMocks.CountriesJson)
+                endpoint.contains("/api/v0.6/credential-types") ->
+                    Route(200, Request.ContentTypeApplicationJson, CredentialTypesMocks.CredentialTypesJson)
+                endpoint.contains("/schemas/") ->
+                    Route(200, Request.ContentTypeApplicationJson, CredentialTypeSchemaMocks.CredentialTypeSchemaJson)
+                endpoint.contains("/verified-profile") ->
+                    Route(verifiedProfileStatusCode, verifiedProfileContentType, verifiedProfilePayload)
+                endpoint.contains("/resolve-did/") ->
+                    Route(didDocumentStatusCode, didDocumentContentType, didDocumentPayload)
+                isSdkRequestEndpoint(endpoint) ->
+                    Route(requestStatusCode, requestContentType, requestPayload)
+                else ->
+                    error("Unhandled HTTP endpoint in baseline test: $endpoint")
+            }
+
+        private fun isSdkRequestEndpoint(endpoint: String): Boolean =
+            endpoint.contains("get-credential-manifest") ||
+                endpoint.contains("get-presentation-request") ||
+                endpoint.startsWith("not-a-url") ||
+                endpoint.startsWith("ftp://")
+    }
+
+    private data class Route(
+        val statusCode: Int,
+        val contentType: String?,
+        val payload: String,
+    )
+
+    private class FakeHttpURLConnection(
+        url: URL,
+        private val responseCodeValue: Int,
+        private val contentTypeValue: String?,
+        private val payload: String,
+    ) : HttpURLConnection(url) {
+        override fun connect() = Unit
+
+        override fun disconnect() = Unit
+
+        override fun usingProxy() = false
+
+        override fun getResponseCode(): Int = responseCodeValue
+
+        override fun getContentType(): String? = contentTypeValue
+
+        override fun getErrorStream(): InputStream? =
+            if (responseCodeValue >= HTTP_OK && responseCodeValue <= 299) {
+                null
+            } else {
+                ByteArrayInputStream(payload.toByteArray())
+            }
+
+        override fun getInputStream(): InputStream =
+            ByteArrayInputStream(payload.toByteArray())
+    }
+
+    private companion object {
+        val cacheSequence = AtomicInteger(1000)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds Android SDK baseline tests for the current error behavior across the issue #3143 taxonomy scenarios.
- Wires an internal `HttpURLConnection` factory through `VCLImpl` and `VclBlocksProvider` so the baseline tests can exercise SDK entry points without real network calls.
- Locks down current backwards-compatibility behavior before changing SDK error codes.

## Validation

- PASS: `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.backwardscompatibility.ErrorTaxonomyBackwardCompatibilityBaselineTest`
- PASS: `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.backwardscompatibility.ErrorTaxonomyBackwardCompatibilityBaselineTest --rerun-tasks`
- PASS: debug unit tests during `./gradlew VCL:test`
- FAIL: `./gradlew VCL:test` has existing release-variant failures unrelated to this diff: `FinalizeOffersUseCaseTest.testPassedCredentials` and `CredentialDidVerifierTest.testVerifyCredentialsFailed`.
