### PR TITLE
[codex] Refactor error taxonomy integration tests

### DIFF
--- a/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLErrorCode.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/api/entities/error/VCLErrorCode.kt
@@ -33,6 +33,7 @@ enum class VCLErrorCode(val value: String) {
     ClientRequestRejected("client_request_rejected"),
     IssuerDidUnresolvable("issuer_did_unresolvable"),
     VerifierDidUnresolvable("verifier_did_unresolvable"),
+    RegistrationCheckInconclusive("registration_check_inconclusive"),
     IssuerNotRegistered("issuer_not_registered"),
     VerifierNotRegistered("verifier_not_registered"),
     IssuerRequestInvalid("issuer_request_invalid"),

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
@@ -33,23 +33,20 @@ internal class CredentialManifestRepositoryImpl(
                 result.handleResult(
                     { credentialManifestResponse ->
                         try {
-                            val payload = JSONObject(credentialManifestResponse.payload)
-                            if (!payload.has(VCLCredentialManifest.KeyIssuingRequest)) {
+                            val jwtStr = JSONObject(credentialManifestResponse.payload)
+                                .optString(VCLCredentialManifest.KeyIssuingRequest)
+                            if (jwtStr.isBlank()) {
                                 completionBlock(
                                     VCLResult.Failure(
-                                        ErrorTaxonomy.toClientRequestFetchError(
+                                        ErrorTaxonomy.toRequestValidationError(
                                             VCLError(message = "Missing issuing_request"),
-                                            requestUri = endpoint,
                                             requestKind = ErrorTaxonomy.RequestKindIssuing,
+                                            requestDid = credentialManifestDescriptor.did,
                                         )
                                     )
                                 )
                             } else {
-                                completionBlock(
-                                    VCLResult.Success(
-                                        payload.optString(VCLCredentialManifest.KeyIssuingRequest)
-                                    )
-                                )
+                                completionBlock(VCLResult.Success(jwtStr))
                             }
                         } catch (ex: Exception) {
                             completionBlock(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
@@ -14,7 +14,6 @@ import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
 import io.velocitycareerlabs.impl.domain.repositories.CredentialManifestRepository
 import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
 import org.json.JSONObject
-import java.lang.Exception
 
 internal class CredentialManifestRepositoryImpl(
     val networkService: NetworkService
@@ -32,32 +31,23 @@ internal class CredentialManifestRepositoryImpl(
             completionBlock = { result ->
                 result.handleResult(
                     { credentialManifestResponse ->
-                        try {
-                            val jwtStr = JSONObject(credentialManifestResponse.payload)
+                        val jwtStr = runCatching {
+                            JSONObject(credentialManifestResponse.payload)
                                 .optString(VCLCredentialManifest.KeyIssuingRequest)
-                            if (jwtStr.isBlank()) {
-                                completionBlock(
-                                    VCLResult.Failure(
-                                        ErrorTaxonomy.toRequestValidationError(
-                                            VCLError(message = "Missing issuing_request"),
-                                            requestKind = ErrorTaxonomy.RequestKindIssuing,
-                                            requestDid = credentialManifestDescriptor.did,
-                                        )
-                                    )
-                                )
-                            } else {
-                                completionBlock(VCLResult.Success(jwtStr))
-                            }
-                        } catch (ex: Exception) {
+                        }.getOrDefault("")
+                        if (jwtStr.isBlank()) {
                             completionBlock(
                                 VCLResult.Failure(
-                                    ErrorTaxonomy.toClientRequestFetchError(
-                                        VCLError(ex),
-                                        requestUri = endpoint,
+                                    ErrorTaxonomy.toRequestValidationError(
+                                        VCLError(message = "Missing issuing_request"),
                                         requestKind = ErrorTaxonomy.RequestKindIssuing,
+                                        requestDid = credentialManifestDescriptor.did,
+                                        requestUri = endpoint,
                                     )
                                 )
                             )
+                        } else {
+                            completionBlock(VCLResult.Success(jwtStr))
                         }
                     },
                     { error ->

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
@@ -33,9 +33,8 @@ internal class CredentialManifestRepositoryImpl(
                 result.handleResult(
                     { credentialManifestResponse ->
                         try {
-                            val jwtStr = JSONObject(credentialManifestResponse.payload)
-                                .optString(VCLCredentialManifest.KeyIssuingRequest)
-                            if (jwtStr.isBlank()) {
+                            val payload = JSONObject(credentialManifestResponse.payload)
+                            if (!payload.has(VCLCredentialManifest.KeyIssuingRequest)) {
                                 completionBlock(
                                     VCLResult.Failure(
                                         ErrorTaxonomy.toClientRequestFetchError(
@@ -46,7 +45,11 @@ internal class CredentialManifestRepositoryImpl(
                                     )
                                 )
                             } else {
-                                completionBlock(VCLResult.Success(jwtStr))
+                                completionBlock(
+                                    VCLResult.Success(
+                                        payload.optString(VCLCredentialManifest.KeyIssuingRequest)
+                                    )
+                                )
                             }
                         } catch (ex: Exception) {
                             completionBlock(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/CredentialManifestRepositoryImpl.kt
@@ -13,7 +13,6 @@ import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
 import io.velocitycareerlabs.impl.domain.repositories.CredentialManifestRepository
 import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
-import io.velocitycareerlabs.impl.utils.VelocityDeepLinkValidator
 import org.json.JSONObject
 import java.lang.Exception
 
@@ -25,66 +24,55 @@ internal class CredentialManifestRepositoryImpl(
         credentialManifestDescriptor: VCLCredentialManifestDescriptor,
         completionBlock: (VCLResult<String>) -> Unit
     ) {
-        credentialManifestDescriptor.endpoint?.let { endpoint ->
-            networkService.sendRequest(
-                endpoint = endpoint,
-                method = Request.HttpMethod.GET,
-                headers = listOf(Pair(HeaderKeys.XVnfProtocolVersion, HeaderValues.XVnfProtocolVersion)),
-                completionBlock = { result ->
-                    result.handleResult(
-                        { credentialManifestResponse ->
-                            try {
-                                val jwtStr = JSONObject(credentialManifestResponse.payload)
-                                    .optString(VCLCredentialManifest.KeyIssuingRequest)
-                                if (jwtStr.isBlank()) {
-                                    completionBlock(
-                                        VCLResult.Failure(
-                                            ErrorTaxonomy.toClientRequestFetchError(
-                                                VCLError(message = "Missing issuing_request"),
-                                                requestUri = endpoint,
-                                                requestKind = ErrorTaxonomy.RequestKindIssuing,
-                                            )
-                                        )
-                                    )
-                                } else {
-                                    completionBlock(VCLResult.Success(jwtStr))
-                                }
-                            } catch (ex: Exception) {
+        val endpoint = credentialManifestDescriptor.endpoint.orEmpty()
+        networkService.sendRequest(
+            endpoint = endpoint,
+            method = Request.HttpMethod.GET,
+            headers = listOf(Pair(HeaderKeys.XVnfProtocolVersion, HeaderValues.XVnfProtocolVersion)),
+            completionBlock = { result ->
+                result.handleResult(
+                    { credentialManifestResponse ->
+                        try {
+                            val jwtStr = JSONObject(credentialManifestResponse.payload)
+                                .optString(VCLCredentialManifest.KeyIssuingRequest)
+                            if (jwtStr.isBlank()) {
                                 completionBlock(
                                     VCLResult.Failure(
                                         ErrorTaxonomy.toClientRequestFetchError(
-                                            VCLError(ex),
+                                            VCLError(message = "Missing issuing_request"),
                                             requestUri = endpoint,
                                             requestKind = ErrorTaxonomy.RequestKindIssuing,
                                         )
                                     )
                                 )
+                            } else {
+                                completionBlock(VCLResult.Success(jwtStr))
                             }
-                        },
-                        { error ->
+                        } catch (ex: Exception) {
                             completionBlock(
                                 VCLResult.Failure(
                                     ErrorTaxonomy.toClientRequestFetchError(
-                                        error,
+                                        VCLError(ex),
                                         requestUri = endpoint,
                                         requestKind = ErrorTaxonomy.RequestKindIssuing,
                                     )
                                 )
                             )
                         }
-                    )
-                }
-            )
-        } ?: run {
-            completionBlock(
-                VCLResult.Failure(
-                    ErrorTaxonomy.invalidLink(
-                        message = "credentialManifestDescriptor.endpoint = null",
-                        sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
-                        requestKind = ErrorTaxonomy.RequestKindIssuing,
-                    )
+                    },
+                    { error ->
+                        completionBlock(
+                            VCLResult.Failure(
+                                ErrorTaxonomy.toClientRequestFetchError(
+                                    error,
+                                    requestUri = endpoint,
+                                    requestKind = ErrorTaxonomy.RequestKindIssuing,
+                                )
+                            )
+                        )
+                    }
                 )
-            )
-        }
+            }
+        )
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/JwtServiceRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/JwtServiceRepositoryImpl.kt
@@ -24,9 +24,12 @@ internal class JwtServiceRepositoryImpl(
         completionBlock: (VCLResult<VCLJwt>) -> Unit
     ) {
         try {
-            completionBlock(
-                VCLResult.Success(VCLJwt(encodedJwt))
-            )
+            val jwt = VCLJwt(encodedJwt)
+            if (jwt.signedJwt == null) {
+                completionBlock(VCLResult.Failure(VCLError(message = "Malformed JWT")))
+            } else {
+                completionBlock(VCLResult.Success(jwt))
+            }
         } catch (ex: Exception) {
             completionBlock(VCLResult.Failure(VCLError(ex)))
         }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
@@ -34,23 +34,20 @@ internal class PresentationRequestRepositoryImpl(
             completionBlock = { encodedJwtResult ->
                 encodedJwtResult.handleResult({ presentationRequestResponse ->
                     try {
-                        val payload = JSONObject(presentationRequestResponse.payload)
-                        if (!payload.has(VCLPresentationRequest.KeyPresentationRequest)) {
+                        val encodedJwtStr = JSONObject(presentationRequestResponse.payload)
+                            .optString(VCLPresentationRequest.KeyPresentationRequest)
+                        if (encodedJwtStr.isBlank()) {
                             completionBlock(
                                 VCLResult.Failure(
-                                    ErrorTaxonomy.toClientRequestFetchError(
+                                    ErrorTaxonomy.toRequestValidationError(
                                         VCLError(message = "Missing presentation_request"),
-                                        requestUri = endpoint,
                                         requestKind = ErrorTaxonomy.RequestKindPresentation,
+                                        requestDid = presentationRequestDescriptor.did,
                                     )
                                 )
                             )
                         } else {
-                            completionBlock(
-                                VCLResult.Success(
-                                    payload.optString(VCLPresentationRequest.KeyPresentationRequest)
-                                )
-                            )
+                            completionBlock(VCLResult.Success(encodedJwtStr))
                         }
                     } catch (ex: Exception) {
                         completionBlock(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
@@ -13,7 +13,6 @@ import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.impl.domain.repositories.PresentationRequestRepository
 import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
 import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
-import io.velocitycareerlabs.impl.utils.VelocityDeepLinkValidator
 import org.json.JSONObject
 import java.lang.Exception
 
@@ -26,64 +25,53 @@ internal class PresentationRequestRepositoryImpl(
         presentationRequestDescriptor: VCLPresentationRequestDescriptor,
         completionBlock: (VCLResult<String>) -> Unit
     ) {
-        presentationRequestDescriptor.endpoint?.let { endpoint ->
-            networkService.sendRequest(
-                endpoint = endpoint,
-                contentType = Request.ContentTypeApplicationJson,
-                method = Request.HttpMethod.GET,
-                headers = listOf(Pair(HeaderKeys.XVnfProtocolVersion, HeaderValues.XVnfProtocolVersion)),
-                completionBlock = { encodedJwtResult ->
-                    encodedJwtResult.handleResult({ presentationRequestResponse ->
-                        try {
-                            val encodedJwtStr = JSONObject(presentationRequestResponse.payload)
-                                .optString(VCLPresentationRequest.KeyPresentationRequest)
-                            if (encodedJwtStr.isBlank()) {
-                                completionBlock(
-                                    VCLResult.Failure(
-                                        ErrorTaxonomy.toClientRequestFetchError(
-                                            VCLError(message = "Missing presentation_request"),
-                                            requestUri = endpoint,
-                                            requestKind = ErrorTaxonomy.RequestKindPresentation,
-                                        )
-                                    )
-                                )
-                            } else {
-                                completionBlock(VCLResult.Success(encodedJwtStr))
-                            }
-                        } catch (ex: Exception) {
+        val endpoint = presentationRequestDescriptor.endpoint.orEmpty()
+        networkService.sendRequest(
+            endpoint = endpoint,
+            contentType = Request.ContentTypeApplicationJson,
+            method = Request.HttpMethod.GET,
+            headers = listOf(Pair(HeaderKeys.XVnfProtocolVersion, HeaderValues.XVnfProtocolVersion)),
+            completionBlock = { encodedJwtResult ->
+                encodedJwtResult.handleResult({ presentationRequestResponse ->
+                    try {
+                        val encodedJwtStr = JSONObject(presentationRequestResponse.payload)
+                            .optString(VCLPresentationRequest.KeyPresentationRequest)
+                        if (encodedJwtStr.isBlank()) {
                             completionBlock(
                                 VCLResult.Failure(
                                     ErrorTaxonomy.toClientRequestFetchError(
-                                        VCLError(ex),
+                                        VCLError(message = "Missing presentation_request"),
                                         requestUri = endpoint,
                                         requestKind = ErrorTaxonomy.RequestKindPresentation,
                                     )
                                 )
                             )
+                        } else {
+                            completionBlock(VCLResult.Success(encodedJwtStr))
                         }
-                    }, {
+                    } catch (ex: Exception) {
                         completionBlock(
                             VCLResult.Failure(
                                 ErrorTaxonomy.toClientRequestFetchError(
-                                    it,
+                                    VCLError(ex),
                                     requestUri = endpoint,
                                     requestKind = ErrorTaxonomy.RequestKindPresentation,
                                 )
                             )
                         )
-                    })
-                }
-            )
-        } ?: run {
-            completionBlock(
-                VCLResult.Failure(
-                    ErrorTaxonomy.invalidLink(
-                        message = "presentationRequestDescriptor.endpoint = null",
-                        sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
-                        requestKind = ErrorTaxonomy.RequestKindPresentation,
+                    }
+                }, {
+                    completionBlock(
+                        VCLResult.Failure(
+                            ErrorTaxonomy.toClientRequestFetchError(
+                                it,
+                                requestUri = endpoint,
+                                requestKind = ErrorTaxonomy.RequestKindPresentation,
+                            )
+                        )
                     )
-                )
-            )
-        }
+                })
+            }
+        )
     }
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
@@ -14,7 +14,6 @@ import io.velocitycareerlabs.impl.domain.repositories.PresentationRequestReposit
 import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
 import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
 import org.json.JSONObject
-import java.lang.Exception
 
 internal class PresentationRequestRepositoryImpl(
     private val networkService: NetworkService
@@ -33,32 +32,23 @@ internal class PresentationRequestRepositoryImpl(
             headers = listOf(Pair(HeaderKeys.XVnfProtocolVersion, HeaderValues.XVnfProtocolVersion)),
             completionBlock = { encodedJwtResult ->
                 encodedJwtResult.handleResult({ presentationRequestResponse ->
-                    try {
-                        val encodedJwtStr = JSONObject(presentationRequestResponse.payload)
+                    val encodedJwtStr = runCatching {
+                        JSONObject(presentationRequestResponse.payload)
                             .optString(VCLPresentationRequest.KeyPresentationRequest)
-                        if (encodedJwtStr.isBlank()) {
-                            completionBlock(
-                                VCLResult.Failure(
-                                    ErrorTaxonomy.toRequestValidationError(
-                                        VCLError(message = "Missing presentation_request"),
-                                        requestKind = ErrorTaxonomy.RequestKindPresentation,
-                                        requestDid = presentationRequestDescriptor.did,
-                                    )
-                                )
-                            )
-                        } else {
-                            completionBlock(VCLResult.Success(encodedJwtStr))
-                        }
-                    } catch (ex: Exception) {
+                    }.getOrDefault("")
+                    if (encodedJwtStr.isBlank()) {
                         completionBlock(
                             VCLResult.Failure(
-                                ErrorTaxonomy.toClientRequestFetchError(
-                                    VCLError(ex),
-                                    requestUri = endpoint,
+                                ErrorTaxonomy.toRequestValidationError(
+                                    VCLError(message = "Missing presentation_request"),
                                     requestKind = ErrorTaxonomy.RequestKindPresentation,
+                                    requestDid = presentationRequestDescriptor.did,
+                                    requestUri = endpoint,
                                 )
                             )
                         )
+                    } else {
+                        completionBlock(VCLResult.Success(encodedJwtStr))
                     }
                 }, {
                     completionBlock(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/repositories/PresentationRequestRepositoryImpl.kt
@@ -34,9 +34,8 @@ internal class PresentationRequestRepositoryImpl(
             completionBlock = { encodedJwtResult ->
                 encodedJwtResult.handleResult({ presentationRequestResponse ->
                     try {
-                        val encodedJwtStr = JSONObject(presentationRequestResponse.payload)
-                            .optString(VCLPresentationRequest.KeyPresentationRequest)
-                        if (encodedJwtStr.isBlank()) {
+                        val payload = JSONObject(presentationRequestResponse.payload)
+                        if (!payload.has(VCLPresentationRequest.KeyPresentationRequest)) {
                             completionBlock(
                                 VCLResult.Failure(
                                     ErrorTaxonomy.toClientRequestFetchError(
@@ -47,7 +46,11 @@ internal class PresentationRequestRepositoryImpl(
                                 )
                             )
                         } else {
-                            completionBlock(VCLResult.Success(encodedJwtStr))
+                            completionBlock(
+                                VCLResult.Success(
+                                    payload.optString(VCLPresentationRequest.KeyPresentationRequest)
+                                )
+                            )
                         }
                     } catch (ex: Exception) {
                         completionBlock(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
@@ -72,6 +72,7 @@ internal class CredentialManifestUseCaseImpl(
                         context.didDocument,
                         context.credentialManifest.remoteCryptoServicesToken,
                         context.credentialManifest.iss,
+                        credentialManifestDescriptor.endpoint,
                         ErrorTaxonomy.RequestKindIssuing,
                     )
                         .map { context }
@@ -106,6 +107,7 @@ internal class CredentialManifestUseCaseImpl(
                             phases.requestValidationError(
                                 jwtResult.error,
                                 credentialManifestDescriptor.did,
+                                credentialManifestDescriptor.endpoint,
                                 ErrorTaxonomy.RequestKindIssuing,
                             )
                         )
@@ -144,6 +146,7 @@ internal class CredentialManifestUseCaseImpl(
                             phases.requestValidationError(
                                 verificationResult.error,
                                 credentialManifest.iss,
+                                credentialManifest.deepLink?.requestUri,
                                 ErrorTaxonomy.RequestKindIssuing,
                             )
                         )
@@ -157,6 +160,7 @@ internal class CredentialManifestUseCaseImpl(
                                     phases.requestValidationError(
                                         VCLError(message = "Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}"),
                                         credentialManifest.iss,
+                                        credentialManifest.deepLink?.requestUri,
                                         ErrorTaxonomy.RequestKindIssuing,
                                     )
                                 )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
@@ -7,7 +7,12 @@
 
 package io.velocitycareerlabs.impl.data.usecases
 
-import io.velocitycareerlabs.api.entities.*
+import io.velocitycareerlabs.api.entities.VCLCredentialManifest
+import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptor
+import io.velocitycareerlabs.api.entities.VCLDidDocument
+import io.velocitycareerlabs.api.entities.VCLJwt
+import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.VCLVerifiedProfile
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.impl.domain.infrastructure.executors.Executor
 import io.velocitycareerlabs.impl.domain.repositories.CredentialManifestRepository
@@ -27,224 +32,156 @@ internal class CredentialManifestUseCaseImpl(
 ): CredentialManifestUseCase {
 
     private val TAG = CredentialManifestUseCaseImpl::class.simpleName
+    private val phases = PublicRequestUseCasePhases(
+        resolveDidDocumentRepository,
+        jwtServiceRepository,
+        executor,
+    )
 
     override fun getCredentialManifest(
         credentialManifestDescriptor: VCLCredentialManifestDescriptor,
         verifiedProfile: VCLVerifiedProfile,
         completionBlock: (VCLResult<VCLCredentialManifest>) -> Unit
     ) {
+        val complete = phases.mainThreadCompletion(completionBlock)
+
         executor.runOnBackground {
-            credentialManifestRepository.getCredentialManifest(
-                credentialManifestDescriptor
-            ) { jwtStrResult ->
-                jwtStrResult.handleResult(
-                    { jwtStr ->
-                        jwtServiceRepository.decode(jwtStr) { jwtResult ->
-                            jwtResult.handleResult({ jwt ->
-                                val credentialManifest = VCLCredentialManifest(
-                                    jwt = jwt,
-                                    vendorOriginContext = credentialManifestDescriptor.vendorOriginContext,
-                                    verifiedProfile = verifiedProfile,
-                                    deepLink = credentialManifestDescriptor.deepLink,
-                                    didJwk = credentialManifestDescriptor.didJwk,
-                                    remoteCryptoServicesToken = credentialManifestDescriptor.remoteCryptoServicesToken
-                                )
-                                resolveDidDocument(credentialManifest, completionBlock) { didDocument ->
-                                    verifyCredentialManifestJwt(
-                                        credentialManifest,
-                                        didDocument,
-                                        completionBlock
-                                    )
-                                }
-                            }, { error ->
-                                onError(
-                                    ErrorTaxonomy.toRequestValidationError(
-                                        error,
-                                        requestKind = ErrorTaxonomy.RequestKindIssuing,
-                                        requestDid = credentialManifestDescriptor.did,
-                                    ),
-                                    completionBlock
-                                )
-                            })
+            clientRequestFetch(credentialManifestDescriptor)
+                .then { jwtStr ->
+                    requestValidationDecode(
+                        jwtStr,
+                        credentialManifestDescriptor,
+                        verifiedProfile
+                    )
+                }
+                .then { credentialManifest ->
+                    phases.didResolution(
+                        credentialManifest.iss,
+                        ErrorTaxonomy.RequestKindIssuing,
+                    )
+                        .map { didDocument ->
+                            CredentialManifestVerificationContext(
+                                credentialManifest,
+                                didDocument
+                            )
                         }
-                    },
-                    { error ->
-                        onError(error, completionBlock)
+                }
+                .then { context ->
+                    phases.requestValidationVerifyJwt(
+                        context.credentialManifest.jwt,
+                        context.didDocument,
+                        context.credentialManifest.remoteCryptoServicesToken,
+                        context.credentialManifest.iss,
+                        ErrorTaxonomy.RequestKindIssuing,
+                    )
+                        .map { context }
+                }
+                .then { context ->
+                    requestValidationVerifyDeepLink(context.credentialManifest, context.didDocument)
+                }
+                .invoke(complete)
+        }
+    }
+
+    private fun clientRequestFetch(
+        credentialManifestDescriptor: VCLCredentialManifestDescriptor,
+    ): VCLAsyncResult<String> =
+        vclAsyncResult { completion ->
+            credentialManifestRepository.getCredentialManifest(
+                credentialManifestDescriptor,
+                completion
+            )
+        }
+
+    private fun requestValidationDecode(
+        jwtStr: String,
+        credentialManifestDescriptor: VCLCredentialManifestDescriptor,
+        verifiedProfile: VCLVerifiedProfile,
+    ): VCLAsyncResult<VCLCredentialManifest> =
+        vclAsyncResult { completion ->
+            jwtServiceRepository.decode(jwtStr) { jwtResult ->
+                completion(
+                    when (jwtResult) {
+                        is VCLResult.Failure -> VCLResult.Failure(
+                            phases.requestValidationError(
+                                jwtResult.error,
+                                credentialManifestDescriptor.did,
+                                ErrorTaxonomy.RequestKindIssuing,
+                            )
+                        )
+                        is VCLResult.Success -> VCLResult.Success(
+                            credentialManifest(
+                                jwtResult.data,
+                                credentialManifestDescriptor,
+                                verifiedProfile
+                            )
+                        )
                     }
                 )
             }
         }
-    }
 
-    private fun verifyCredentialManifestJwt(
+    private fun requestValidationVerifyDeepLink(
         credentialManifest: VCLCredentialManifest,
         didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<VCLCredentialManifest>) -> Unit
-    ) {
-        val kid = credentialManifest.jwt.kid
-            ?: return onError(
-                missingJwtKidError(requestDid = credentialManifest.iss),
-                completionBlock
-            )
-        val publicJwk = didDocument.getPublicJwk(kid)
-            ?: return onError(
-                unresolvedJwtKeyError(kid, requestDid = credentialManifest.iss),
-                completionBlock
-            )
-        jwtServiceRepository.verifyJwt(
-            credentialManifest.jwt,
-            publicJwk,
-            credentialManifest.remoteCryptoServicesToken
-        ) { verificationResult ->
-            verificationResult.handleResult(
-                { isVerified ->
-                    verifyCredentialManifestByDeepLink(
-                        credentialManifest,
-                        didDocument,
-                        completionBlock
-                    )
-                },
-                { error ->
-                    onError(
-                        ErrorTaxonomy.toRequestValidationError(
-                            error,
-                            requestKind = ErrorTaxonomy.RequestKindIssuing,
-                            requestDid = credentialManifest.iss,
-                        ),
-                        completionBlock
-                    )
-                }
-            )
-        }
-    }
+    ): VCLAsyncResult<VCLCredentialManifest> =
+        vclAsyncResult { completion ->
+            val deepLink = credentialManifest.deepLink
+            if (deepLink == null) {
+                VCLLog.d(TAG, "Deep link was not provided => nothing to verify")
+                completion(VCLResult.Success(credentialManifest))
+                return@vclAsyncResult
+            }
 
-    private fun verifyCredentialManifestByDeepLink(
-        credentialManifest: VCLCredentialManifest,
-        didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<VCLCredentialManifest>) -> Unit
-    ) {
-        credentialManifest.deepLink?.let { deepLink ->
             credentialManifestByDeepLinkVerifier.verifyCredentialManifest(
                 credentialManifest,
                 deepLink,
                 didDocument
-            ) {
-                it.handleResult(
-                    { isVerified ->
-                        VCLLog.d(
-                            TAG,
-                            "Credential manifest deep link verification result: $isVerified"
+            ) { verificationResult ->
+                completion(
+                    when (verificationResult) {
+                        is VCLResult.Failure -> VCLResult.Failure(
+                            phases.requestValidationError(
+                                verificationResult.error,
+                                credentialManifest.iss,
+                                ErrorTaxonomy.RequestKindIssuing,
+                            )
                         )
-                        onVerificationSuccess(
-                            isVerified,
-                            credentialManifest,
-                            completionBlock
-                        )
-                    },
-                    { error ->
-                        onError(
-                            ErrorTaxonomy.toRequestValidationError(
-                                error,
-                                requestKind = ErrorTaxonomy.RequestKindIssuing,
-                                requestDid = credentialManifest.iss,
-                            ),
-                            completionBlock
-                        )
+                        is VCLResult.Success -> {
+                            val isVerified = verificationResult.data
+                            VCLLog.d(TAG, "Credential manifest deep link verification result: $isVerified")
+                            if (isVerified) {
+                                VCLResult.Success(credentialManifest)
+                            } else {
+                                VCLResult.Failure(
+                                    phases.requestValidationError(
+                                        VCLError(message = "Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}"),
+                                        credentialManifest.iss,
+                                        ErrorTaxonomy.RequestKindIssuing,
+                                    )
+                                )
+                            }
+                        }
                     }
                 )
             }
-        } ?: run {
-            VCLLog.d(TAG, "Deep link was not provided => nothing to verify")
-            executor.runOnMain {
-                completionBlock(VCLResult.Success(credentialManifest))
-            }
-        }
-    }
-
-    private fun resolveDidDocument(
-        credentialManifest: VCLCredentialManifest,
-        completionBlock: (VCLResult<VCLCredentialManifest>) -> Unit,
-        successHandler: (VCLDidDocument) -> Unit,
-    ) {
-        resolveDidDocumentRepository.resolveDidDocument(
-            credentialManifest.iss
-        ) { didDocumentResult ->
-            didDocumentResult.handleResult({ didDocument ->
-                validateDidDocument(didDocument, credentialManifest)?.let { error ->
-                    onError(error, completionBlock)
-                } ?: run {
-                    successHandler(didDocument)
-                }
-            }, { error ->
-                onError(
-                    ErrorTaxonomy.toDidResolutionError(
-                        error,
-                        requestKind = ErrorTaxonomy.RequestKindIssuing,
-                        requestDid = credentialManifest.iss,
-                    ),
-                    completionBlock
-                )
-            })
-        }
-    }
-
-    private fun missingJwtKidError(requestDid: String?): VCLError =
-        ErrorTaxonomy.toRequestValidationError(
-            VCLError(message = "JWT kid is missing"),
-            requestKind = ErrorTaxonomy.RequestKindIssuing,
-            requestDid = requestDid,
-        )
-
-    private fun validateDidDocument(
-        didDocument: VCLDidDocument,
-        credentialManifest: VCLCredentialManifest,
-    ): VCLError? =
-        if (didDocument.payload.length() == 0 ||
-            (didDocument.payload.optJSONArray(VCLDidDocument.KeyVerificationMethod)?.length() ?: 0) == 0
-        ) {
-            ErrorTaxonomy.toDidResolutionError(
-                VCLError(message = "public jwk not found for kid"),
-                requestKind = ErrorTaxonomy.RequestKindIssuing,
-                requestDid = credentialManifest.iss,
-            )
-        } else {
-            null
         }
 
-    private fun unresolvedJwtKeyError(kid: String, requestDid: String?): VCLError =
-        ErrorTaxonomy.toRequestValidationError(
-            VCLError(message = "public jwk not found for kid: $kid"),
-            requestKind = ErrorTaxonomy.RequestKindIssuing,
-            requestDid = requestDid,
-        )
+    private fun credentialManifest(
+        jwt: VCLJwt,
+        credentialManifestDescriptor: VCLCredentialManifestDescriptor,
+        verifiedProfile: VCLVerifiedProfile,
+    ) = VCLCredentialManifest(
+        jwt = jwt,
+        vendorOriginContext = credentialManifestDescriptor.vendorOriginContext,
+        verifiedProfile = verifiedProfile,
+        deepLink = credentialManifestDescriptor.deepLink,
+        didJwk = credentialManifestDescriptor.didJwk,
+        remoteCryptoServicesToken = credentialManifestDescriptor.remoteCryptoServicesToken
+    )
 
-    private fun onVerificationSuccess(
-        isVerified: Boolean,
-        credentialManifest: VCLCredentialManifest,
-        completionBlock: (VCLResult<VCLCredentialManifest>) -> Unit
-    ) {
-        if (isVerified) {
-            executor.runOnMain {
-                completionBlock(VCLResult.Success(credentialManifest))
-            }
-        } else {
-            onError(
-                ErrorTaxonomy.toRequestValidationError(
-                    VCLError(message = "Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}"),
-                    requestKind = ErrorTaxonomy.RequestKindIssuing,
-                    requestDid = credentialManifest.iss,
-                ),
-                completionBlock
-            )
-        }
-    }
-
-    private fun onError(
-        error: VCLError,
-        completionBlock: (VCLResult<VCLCredentialManifest>) -> Unit
-    ) {
-        executor.runOnMain {
-            completionBlock(VCLResult.Failure(error))
-        }
-    }
+    private data class CredentialManifestVerificationContext(
+        val credentialManifest: VCLCredentialManifest,
+        val didDocument: VCLDidDocument,
+    )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
@@ -117,7 +117,15 @@ internal class CredentialManifestUseCaseImpl(
                                 credentialManifestDescriptor,
                                 verifiedProfile
                             )
-                        )
+                        ).takeUnless { it.data.iss.isBlank() }
+                            ?: VCLResult.Failure(
+                                phases.requestValidationError(
+                                    VCLError(message = "Missing iss"),
+                                    credentialManifestDescriptor.did,
+                                    credentialManifestDescriptor.endpoint,
+                                    ErrorTaxonomy.RequestKindIssuing,
+                                )
+                            )
                     }
                 )
             }
@@ -151,20 +159,8 @@ internal class CredentialManifestUseCaseImpl(
                             )
                         )
                         is VCLResult.Success -> {
-                            val isVerified = verificationResult.data
-                            VCLLog.d(TAG, "Credential manifest deep link verification result: $isVerified")
-                            if (isVerified) {
-                                VCLResult.Success(credentialManifest)
-                            } else {
-                                VCLResult.Failure(
-                                    phases.requestValidationError(
-                                        VCLError(message = "Failed to verify credentialManifest jwt:\n${credentialManifest.jwt}"),
-                                        credentialManifest.iss,
-                                        credentialManifest.deepLink?.requestUri,
-                                        ErrorTaxonomy.RequestKindIssuing,
-                                    )
-                                )
-                            }
+                            VCLLog.d(TAG, "Credential manifest deep link verification succeeded")
+                            VCLResult.Success(credentialManifest)
                         }
                     }
                 )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/CredentialManifestUseCaseImpl.kt
@@ -39,31 +39,33 @@ internal class CredentialManifestUseCaseImpl(
             ) { jwtStrResult ->
                 jwtStrResult.handleResult(
                     { jwtStr ->
-                        try {
-                            val credentialManifest = VCLCredentialManifest(
-                                jwt = VCLJwt(jwtStr),
-                                vendorOriginContext = credentialManifestDescriptor.vendorOriginContext,
-                                verifiedProfile = verifiedProfile,
-                                deepLink = credentialManifestDescriptor.deepLink,
-                                didJwk = credentialManifestDescriptor.didJwk,
-                                remoteCryptoServicesToken = credentialManifestDescriptor.remoteCryptoServicesToken
-                            )
-                            resolveDidDocument(credentialManifest, completionBlock) { didDocument ->
-                                verifyCredentialManifestJwt(
-                                    credentialManifest,
-                                    didDocument,
+                        jwtServiceRepository.decode(jwtStr) { jwtResult ->
+                            jwtResult.handleResult({ jwt ->
+                                val credentialManifest = VCLCredentialManifest(
+                                    jwt = jwt,
+                                    vendorOriginContext = credentialManifestDescriptor.vendorOriginContext,
+                                    verifiedProfile = verifiedProfile,
+                                    deepLink = credentialManifestDescriptor.deepLink,
+                                    didJwk = credentialManifestDescriptor.didJwk,
+                                    remoteCryptoServicesToken = credentialManifestDescriptor.remoteCryptoServicesToken
+                                )
+                                resolveDidDocument(credentialManifest, completionBlock) { didDocument ->
+                                    verifyCredentialManifestJwt(
+                                        credentialManifest,
+                                        didDocument,
+                                        completionBlock
+                                    )
+                                }
+                            }, { error ->
+                                onError(
+                                    ErrorTaxonomy.toRequestValidationError(
+                                        error,
+                                        requestKind = ErrorTaxonomy.RequestKindIssuing,
+                                        requestDid = credentialManifestDescriptor.did,
+                                    ),
                                     completionBlock
                                 )
-                            }
-                        } catch (ex: Exception) {
-                            this.onError(
-                                ErrorTaxonomy.toClientRequestFetchError(
-                                    VCLError(ex),
-                                    requestUri = credentialManifestDescriptor.endpoint,
-                                    requestKind = ErrorTaxonomy.RequestKindIssuing,
-                                ),
-                                completionBlock
-                            )
+                            })
                         }
                     },
                     { error ->

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
@@ -71,6 +71,7 @@ internal class PresentationRequestUseCaseImpl(
                         context.didDocument,
                         context.presentationRequest.remoteCryptoServicesToken,
                         context.presentationRequest.iss,
+                        presentationRequestDescriptor.endpoint,
                         ErrorTaxonomy.RequestKindPresentation,
                     )
                         .map { context }
@@ -105,6 +106,7 @@ internal class PresentationRequestUseCaseImpl(
                             phases.requestValidationError(
                                 jwtResult.error,
                                 presentationRequestDescriptor.did,
+                                presentationRequestDescriptor.endpoint,
                                 ErrorTaxonomy.RequestKindPresentation,
                             )
                         )
@@ -136,6 +138,7 @@ internal class PresentationRequestUseCaseImpl(
                             phases.requestValidationError(
                                 byDeepLinkVerificationResult.error,
                                 presentationRequest.iss,
+                                presentationRequest.deepLink.requestUri,
                                 ErrorTaxonomy.RequestKindPresentation,
                             )
                         )
@@ -149,6 +152,7 @@ internal class PresentationRequestUseCaseImpl(
                                     phases.requestValidationError(
                                         VCLError(message = "Failed to verify: ${presentationRequest.jwt.payload}"),
                                         presentationRequest.iss,
+                                        presentationRequest.deepLink.requestUri,
                                         ErrorTaxonomy.RequestKindPresentation,
                                     )
                                 )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
@@ -116,7 +116,15 @@ internal class PresentationRequestUseCaseImpl(
                                 presentationRequestDescriptor,
                                 verifiedProfile
                             )
-                        )
+                        ).takeUnless { it.data.iss.isBlank() }
+                            ?: VCLResult.Failure(
+                                phases.requestValidationError(
+                                    VCLError(message = "Missing iss"),
+                                    presentationRequestDescriptor.did,
+                                    presentationRequestDescriptor.endpoint,
+                                    ErrorTaxonomy.RequestKindPresentation,
+                                )
+                            )
                     }
                 )
             }
@@ -143,20 +151,8 @@ internal class PresentationRequestUseCaseImpl(
                             )
                         )
                         is VCLResult.Success -> {
-                            val isVerified = byDeepLinkVerificationResult.data
-                            VCLLog.d(TAG, "Presentation request by deep link verification result: $isVerified")
-                            if (isVerified) {
-                                VCLResult.Success(presentationRequest)
-                            } else {
-                                VCLResult.Failure(
-                                    phases.requestValidationError(
-                                        VCLError(message = "Failed to verify: ${presentationRequest.jwt.payload}"),
-                                        presentationRequest.iss,
-                                        presentationRequest.deepLink.requestUri,
-                                        ErrorTaxonomy.RequestKindPresentation,
-                                    )
-                                )
-                            }
+                            VCLLog.d(TAG, "Presentation request by deep link verification succeeded")
+                            VCLResult.Success(presentationRequest)
                         }
                     }
                 )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
@@ -6,13 +6,19 @@
  */
 package io.velocitycareerlabs.impl.data.usecases
 
-import io.velocitycareerlabs.api.entities.*
+import io.velocitycareerlabs.api.entities.VCLDidDocument
+import io.velocitycareerlabs.api.entities.VCLJwt
+import io.velocitycareerlabs.api.entities.VCLPresentationRequest
+import io.velocitycareerlabs.api.entities.VCLPresentationRequestDescriptor
+import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.VCLVerifiedProfile
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.impl.domain.infrastructure.executors.Executor
-import io.velocitycareerlabs.impl.domain.repositories.*
+import io.velocitycareerlabs.impl.domain.repositories.JwtServiceRepository
+import io.velocitycareerlabs.impl.domain.repositories.PresentationRequestRepository
+import io.velocitycareerlabs.impl.domain.repositories.ResolveDidDocumentRepository
 import io.velocitycareerlabs.impl.domain.usecases.PresentationRequestUseCase
 import io.velocitycareerlabs.impl.domain.verifiers.PresentationRequestByDeepLinkVerifier
-import io.velocitycareerlabs.impl.extensions.encode
 import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
 import io.velocitycareerlabs.impl.utils.VCLLog
 
@@ -25,198 +31,149 @@ internal class PresentationRequestUseCaseImpl(
 ): PresentationRequestUseCase {
 
     private val TAG = PresentationRequestUseCaseImpl::class.simpleName
+    private val phases = PublicRequestUseCasePhases(
+        resolveDidDocumentRepository,
+        jwtServiceRepository,
+        executor,
+    )
 
     override fun getPresentationRequest(
         presentationRequestDescriptor: VCLPresentationRequestDescriptor,
         verifiedProfile: VCLVerifiedProfile,
         completionBlock: (VCLResult<VCLPresentationRequest>) -> Unit
     ) {
+        val complete = phases.mainThreadCompletion(completionBlock)
+
         executor.runOnBackground {
-            presentationRequestRepository.getPresentationRequest(
-                presentationRequestDescriptor
-            ) { encodedJwtStrResult ->
-                encodedJwtStrResult.handleResult(
-                    { encodedJwtStr ->
-                        jwtServiceRepository.decode(encodedJwtStr) { jwtResult ->
-                            jwtResult.handleResult({ jwt ->
-                                val presentationRequest = VCLPresentationRequest(
-                                    jwt = jwt,
-                                    verifiedProfile = verifiedProfile,
-                                    deepLink = presentationRequestDescriptor.deepLink,
-                                    pushDelegate = presentationRequestDescriptor.pushDelegate,
-                                    didJwk = presentationRequestDescriptor.didJwk,
-                                    remoteCryptoServicesToken = presentationRequestDescriptor.remoteCryptoServicesToken
-                                )
-                                resolveDidDocument(presentationRequest, completionBlock) { didDocument ->
-                                    verifyPresentationRequest(
-                                        presentationRequest,
-                                        didDocument,
-                                        completionBlock
-                                    )
-                                }
-                            }, { error ->
-                                onError(
-                                    ErrorTaxonomy.toRequestValidationError(
-                                        error,
-                                        requestKind = ErrorTaxonomy.RequestKindPresentation,
-                                        requestDid = presentationRequestDescriptor.did,
-                                    ),
-                                    completionBlock
-                                )
-                            })
-                        }
-                    },
-                    { error ->
-                        onError(error, completionBlock)
-                    }
-                )
-            }
-        }
-    }
-
-    private fun verifyPresentationRequest(
-        presentationRequest: VCLPresentationRequest,
-        didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<VCLPresentationRequest>) -> Unit
-    ) {
-        val kid = presentationRequest.jwt.kid
-            ?: return onError(
-                missingJwtKidError(requestDid = presentationRequest.iss),
-                completionBlock
-            )
-        val publicJwk = didDocument.getPublicJwk(kid = kid)
-            ?: return onError(
-                unresolvedJwtKeyError(kid, requestDid = presentationRequest.iss),
-                completionBlock
-            )
-        jwtServiceRepository.verifyJwt(
-            presentationRequest.jwt,
-            publicJwk,
-            presentationRequest.remoteCryptoServicesToken
-        ) { jwtVerificationRes ->
-            jwtVerificationRes.handleResult({
-                presentationRequestByDeepLinkVerifier.verifyPresentationRequest(
-                    presentationRequest,
-                    presentationRequest.deepLink,
-                    didDocument
-                ) { byDeepLinkVerificationRes ->
-                    byDeepLinkVerificationRes.handleResult({ isVerified ->
-                        VCLLog.d(TAG, "Presentation request by deep link verification result: $isVerified")
-                        onVerificationSuccess(
-                            isVerified,
-                            presentationRequest,
-                            completionBlock
-                        )
-                    }, { error ->
-                        onError(
-                            ErrorTaxonomy.toRequestValidationError(
-                                error,
-                                requestKind = ErrorTaxonomy.RequestKindPresentation,
-                                requestDid = presentationRequest.iss,
-                            ),
-                            completionBlock
-                        )
-                    })
-                }
-            }, { error ->
-                onError(
-                    ErrorTaxonomy.toRequestValidationError(
-                        error,
-                        requestKind = ErrorTaxonomy.RequestKindPresentation,
-                        requestDid = presentationRequest.iss,
-                    ),
-                    completionBlock
-                )
-            })
-        }
-    }
-
-    private fun resolveDidDocument(
-        presentationRequest: VCLPresentationRequest,
-        completionBlock: (VCLResult<VCLPresentationRequest>) -> Unit,
-        successHandler: (VCLDidDocument) -> Unit,
-    ) {
-        resolveDidDocumentRepository.resolveDidDocument(
-            did = presentationRequest.iss
-        ) { didDocumentResult ->
-            didDocumentResult.handleResult(
-                { didDocument ->
-                    validateDidDocument(didDocument, presentationRequest)?.let { error ->
-                        onError(error, completionBlock)
-                    } ?: run {
-                        successHandler(didDocument)
-                    }
-                },
-                { error ->
-                    onError(
-                        ErrorTaxonomy.toDidResolutionError(
-                            error,
-                            requestKind = ErrorTaxonomy.RequestKindPresentation,
-                            requestDid = presentationRequest.iss,
-                        ),
-                        completionBlock
+            clientRequestFetch(presentationRequestDescriptor)
+                .then { encodedJwtStr ->
+                    requestValidationDecode(
+                        encodedJwtStr,
+                        presentationRequestDescriptor,
+                        verifiedProfile
                     )
                 }
-            )
+                .then { presentationRequest ->
+                    phases.didResolution(
+                        presentationRequest.iss,
+                        ErrorTaxonomy.RequestKindPresentation,
+                    )
+                        .map { didDocument ->
+                            PresentationRequestVerificationContext(
+                                presentationRequest,
+                                didDocument
+                            )
+                        }
+                }
+                .then { context ->
+                    phases.requestValidationVerifyJwt(
+                        context.presentationRequest.jwt,
+                        context.didDocument,
+                        context.presentationRequest.remoteCryptoServicesToken,
+                        context.presentationRequest.iss,
+                        ErrorTaxonomy.RequestKindPresentation,
+                    )
+                        .map { context }
+                }
+                .then { context ->
+                    requestValidationVerifyDeepLink(context.presentationRequest, context.didDocument)
+                }
+                .invoke(complete)
         }
     }
 
-    private fun missingJwtKidError(requestDid: String?): VCLError =
-        ErrorTaxonomy.toRequestValidationError(
-            VCLError(message = "JWT kid is missing"),
-            requestKind = ErrorTaxonomy.RequestKindPresentation,
-            requestDid = requestDid,
-        )
-
-    private fun validateDidDocument(
-        didDocument: VCLDidDocument,
-        presentationRequest: VCLPresentationRequest,
-    ): VCLError? =
-        if (didDocument.payload.length() == 0 ||
-            (didDocument.payload.optJSONArray(VCLDidDocument.KeyVerificationMethod)?.length() ?: 0) == 0
-        ) {
-            ErrorTaxonomy.toDidResolutionError(
-                VCLError(message = "public jwk not found for kid"),
-                requestKind = ErrorTaxonomy.RequestKindPresentation,
-                requestDid = presentationRequest.iss,
+    private fun clientRequestFetch(
+        presentationRequestDescriptor: VCLPresentationRequestDescriptor,
+    ): VCLAsyncResult<String> =
+        vclAsyncResult { completion ->
+            presentationRequestRepository.getPresentationRequest(
+                presentationRequestDescriptor,
+                completion
             )
-        } else {
-            null
         }
 
-    private fun unresolvedJwtKeyError(kid: String, requestDid: String?): VCLError =
-        ErrorTaxonomy.toRequestValidationError(
-            VCLError(message = "public jwk not found for kid: $kid"),
-            requestKind = ErrorTaxonomy.RequestKindPresentation,
-            requestDid = requestDid,
-        )
-
-    private fun onVerificationSuccess(
-        isVerified: Boolean,
-        presentationRequest: VCLPresentationRequest,
-        completionBlock: (VCLResult<VCLPresentationRequest>) -> Unit
-    ) {
-        if (isVerified)
-            executor.runOnMain {
-                completionBlock(VCLResult.Success(presentationRequest))
+    private fun requestValidationDecode(
+        encodedJwtStr: String,
+        presentationRequestDescriptor: VCLPresentationRequestDescriptor,
+        verifiedProfile: VCLVerifiedProfile,
+    ): VCLAsyncResult<VCLPresentationRequest> =
+        vclAsyncResult { completion ->
+            jwtServiceRepository.decode(encodedJwtStr) { jwtResult ->
+                completion(
+                    when (jwtResult) {
+                        is VCLResult.Failure -> VCLResult.Failure(
+                            phases.requestValidationError(
+                                jwtResult.error,
+                                presentationRequestDescriptor.did,
+                                ErrorTaxonomy.RequestKindPresentation,
+                            )
+                        )
+                        is VCLResult.Success -> VCLResult.Success(
+                            presentationRequest(
+                                jwtResult.data,
+                                presentationRequestDescriptor,
+                                verifiedProfile
+                            )
+                        )
+                    }
+                )
             }
-        else
-            onError(
-                ErrorTaxonomy.toRequestValidationError(
-                    VCLError(message = "Failed to verify: ${presentationRequest.jwt.payload}"),
-                    requestKind = ErrorTaxonomy.RequestKindPresentation,
-                    requestDid = presentationRequest.iss,
-                ),
-                completionBlock
-            )
-    }
-
-    private fun onError(
-        error: VCLError,
-        completionBlock: (VCLResult<VCLPresentationRequest>) -> Unit
-    ) {
-        executor.runOnMain {
-            completionBlock(VCLResult.Failure(error))
         }
-    }
+
+    private fun requestValidationVerifyDeepLink(
+        presentationRequest: VCLPresentationRequest,
+        didDocument: VCLDidDocument,
+    ): VCLAsyncResult<VCLPresentationRequest> =
+        vclAsyncResult { completion ->
+            presentationRequestByDeepLinkVerifier.verifyPresentationRequest(
+                presentationRequest,
+                presentationRequest.deepLink,
+                didDocument
+            ) { byDeepLinkVerificationResult ->
+                completion(
+                    when (byDeepLinkVerificationResult) {
+                        is VCLResult.Failure -> VCLResult.Failure(
+                            phases.requestValidationError(
+                                byDeepLinkVerificationResult.error,
+                                presentationRequest.iss,
+                                ErrorTaxonomy.RequestKindPresentation,
+                            )
+                        )
+                        is VCLResult.Success -> {
+                            val isVerified = byDeepLinkVerificationResult.data
+                            VCLLog.d(TAG, "Presentation request by deep link verification result: $isVerified")
+                            if (isVerified) {
+                                VCLResult.Success(presentationRequest)
+                            } else {
+                                VCLResult.Failure(
+                                    phases.requestValidationError(
+                                        VCLError(message = "Failed to verify: ${presentationRequest.jwt.payload}"),
+                                        presentationRequest.iss,
+                                        ErrorTaxonomy.RequestKindPresentation,
+                                    )
+                                )
+                            }
+                        }
+                    }
+                )
+            }
+        }
+
+    private fun presentationRequest(
+        jwt: VCLJwt,
+        presentationRequestDescriptor: VCLPresentationRequestDescriptor,
+        verifiedProfile: VCLVerifiedProfile,
+    ) = VCLPresentationRequest(
+        jwt = jwt,
+        verifiedProfile = verifiedProfile,
+        deepLink = presentationRequestDescriptor.deepLink,
+        pushDelegate = presentationRequestDescriptor.pushDelegate,
+        didJwk = presentationRequestDescriptor.didJwk,
+        remoteCryptoServicesToken = presentationRequestDescriptor.remoteCryptoServicesToken
+    )
+
+    private data class PresentationRequestVerificationContext(
+        val presentationRequest: VCLPresentationRequest,
+        val didDocument: VCLDidDocument,
+    )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PresentationRequestUseCaseImpl.kt
@@ -37,20 +37,33 @@ internal class PresentationRequestUseCaseImpl(
             ) { encodedJwtStrResult ->
                 encodedJwtStrResult.handleResult(
                     { encodedJwtStr ->
-                        val presentationRequest = VCLPresentationRequest(
-                            jwt = VCLJwt(encodedJwtStr),
-                            verifiedProfile = verifiedProfile,
-                            deepLink = presentationRequestDescriptor.deepLink,
-                            pushDelegate = presentationRequestDescriptor.pushDelegate,
-                            didJwk = presentationRequestDescriptor.didJwk,
-                            remoteCryptoServicesToken = presentationRequestDescriptor.remoteCryptoServicesToken
-                        )
-                        resolveDidDocument(presentationRequest, completionBlock) { didDocument ->
-                            verifyPresentationRequest(
-                                presentationRequest,
-                                didDocument,
-                                completionBlock
-                            )
+                        jwtServiceRepository.decode(encodedJwtStr) { jwtResult ->
+                            jwtResult.handleResult({ jwt ->
+                                val presentationRequest = VCLPresentationRequest(
+                                    jwt = jwt,
+                                    verifiedProfile = verifiedProfile,
+                                    deepLink = presentationRequestDescriptor.deepLink,
+                                    pushDelegate = presentationRequestDescriptor.pushDelegate,
+                                    didJwk = presentationRequestDescriptor.didJwk,
+                                    remoteCryptoServicesToken = presentationRequestDescriptor.remoteCryptoServicesToken
+                                )
+                                resolveDidDocument(presentationRequest, completionBlock) { didDocument ->
+                                    verifyPresentationRequest(
+                                        presentationRequest,
+                                        didDocument,
+                                        completionBlock
+                                    )
+                                }
+                            }, { error ->
+                                onError(
+                                    ErrorTaxonomy.toRequestValidationError(
+                                        error,
+                                        requestKind = ErrorTaxonomy.RequestKindPresentation,
+                                        requestDid = presentationRequestDescriptor.did,
+                                    ),
+                                    completionBlock
+                                )
+                            })
                         }
                     },
                     { error ->

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PublicRequestUseCasePhases.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PublicRequestUseCasePhases.kt
@@ -48,18 +48,19 @@ internal class PublicRequestUseCasePhases(
         didDocument: VCLDidDocument,
         remoteCryptoServicesToken: VCLToken?,
         requestDid: String?,
+        requestUri: String?,
         requestKind: String,
     ): VCLAsyncResult<Unit> =
         vclAsyncResult { completion ->
             val kid = jwt.kid
             if (kid == null) {
-                completion(VCLResult.Failure(missingJwtKidError(requestDid, requestKind)))
+                completion(VCLResult.Failure(missingJwtKidError(requestDid, requestUri, requestKind)))
                 return@vclAsyncResult
             }
 
             val publicJwk = didDocument.getPublicJwk(kid)
             if (publicJwk == null) {
-                completion(VCLResult.Failure(unresolvedJwtKeyError(kid, requestDid, requestKind)))
+                completion(VCLResult.Failure(unresolvedJwtKeyError(kid, requestDid, requestUri, requestKind)))
                 return@vclAsyncResult
             }
 
@@ -74,6 +75,7 @@ internal class PublicRequestUseCasePhases(
                             requestValidationError(
                                 jwtVerificationResult.error,
                                 requestDid,
+                                requestUri,
                                 requestKind,
                             )
                         )
@@ -93,12 +95,14 @@ internal class PublicRequestUseCasePhases(
     fun requestValidationError(
         error: VCLError,
         requestDid: String?,
+        requestUri: String?,
         requestKind: String,
     ): VCLError =
         ErrorTaxonomy.toRequestValidationError(
             error,
             requestKind = requestKind,
             requestDid = requestDid,
+            requestUri = requestUri,
         )
 
     private fun VCLDidDocument.validatedForResolution(
@@ -119,21 +123,28 @@ internal class PublicRequestUseCasePhases(
             null
         }
 
-    private fun missingJwtKidError(requestDid: String?, requestKind: String): VCLError =
+    private fun missingJwtKidError(
+        requestDid: String?,
+        requestUri: String?,
+        requestKind: String,
+    ): VCLError =
         requestValidationError(
             VCLError(message = "JWT kid is missing"),
             requestDid,
+            requestUri,
             requestKind,
         )
 
     private fun unresolvedJwtKeyError(
         kid: String,
         requestDid: String?,
+        requestUri: String?,
         requestKind: String,
     ): VCLError =
         requestValidationError(
             VCLError(message = "public jwk not found for kid: $kid"),
             requestDid,
+            requestUri,
             requestKind,
         )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PublicRequestUseCasePhases.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/PublicRequestUseCasePhases.kt
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.velocitycareerlabs.impl.data.usecases
+
+import io.velocitycareerlabs.api.entities.VCLDidDocument
+import io.velocitycareerlabs.api.entities.VCLJwt
+import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.VCLToken
+import io.velocitycareerlabs.api.entities.error.VCLError
+import io.velocitycareerlabs.impl.domain.infrastructure.executors.Executor
+import io.velocitycareerlabs.impl.domain.repositories.JwtServiceRepository
+import io.velocitycareerlabs.impl.domain.repositories.ResolveDidDocumentRepository
+import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
+
+internal class PublicRequestUseCasePhases(
+    private val resolveDidDocumentRepository: ResolveDidDocumentRepository,
+    private val jwtServiceRepository: JwtServiceRepository,
+    private val executor: Executor,
+) {
+    fun didResolution(
+        did: String,
+        requestKind: String,
+    ): VCLAsyncResult<VCLDidDocument> =
+        vclAsyncResult { completion ->
+            resolveDidDocumentRepository.resolveDidDocument(did) { didDocumentResult ->
+                completion(
+                    when (didDocumentResult) {
+                        is VCLResult.Failure -> VCLResult.Failure(
+                            ErrorTaxonomy.toDidResolutionError(
+                                didDocumentResult.error,
+                                requestKind = requestKind,
+                                requestDid = did,
+                            )
+                        )
+                        is VCLResult.Success -> didDocumentResult.data
+                            .validatedForResolution(did, requestKind)
+                            ?: VCLResult.Success(didDocumentResult.data)
+                    }
+                )
+            }
+        }
+
+    fun requestValidationVerifyJwt(
+        jwt: VCLJwt,
+        didDocument: VCLDidDocument,
+        remoteCryptoServicesToken: VCLToken?,
+        requestDid: String?,
+        requestKind: String,
+    ): VCLAsyncResult<Unit> =
+        vclAsyncResult { completion ->
+            val kid = jwt.kid
+            if (kid == null) {
+                completion(VCLResult.Failure(missingJwtKidError(requestDid, requestKind)))
+                return@vclAsyncResult
+            }
+
+            val publicJwk = didDocument.getPublicJwk(kid)
+            if (publicJwk == null) {
+                completion(VCLResult.Failure(unresolvedJwtKeyError(kid, requestDid, requestKind)))
+                return@vclAsyncResult
+            }
+
+            jwtServiceRepository.verifyJwt(
+                jwt,
+                publicJwk,
+                remoteCryptoServicesToken
+            ) { jwtVerificationResult ->
+                completion(
+                    when (jwtVerificationResult) {
+                        is VCLResult.Failure -> VCLResult.Failure(
+                            requestValidationError(
+                                jwtVerificationResult.error,
+                                requestDid,
+                                requestKind,
+                            )
+                        )
+                        is VCLResult.Success -> VCLResult.Success(Unit)
+                    }
+                )
+            }
+        }
+
+    fun <T> mainThreadCompletion(completionBlock: (VCLResult<T>) -> Unit): (VCLResult<T>) -> Unit =
+        { result ->
+            executor.runOnMain {
+                completionBlock(result)
+            }
+        }
+
+    fun requestValidationError(
+        error: VCLError,
+        requestDid: String?,
+        requestKind: String,
+    ): VCLError =
+        ErrorTaxonomy.toRequestValidationError(
+            error,
+            requestKind = requestKind,
+            requestDid = requestDid,
+        )
+
+    private fun VCLDidDocument.validatedForResolution(
+        requestDid: String?,
+        requestKind: String,
+    ): VCLResult.Failure? =
+        if (payload.length() == 0 ||
+            (payload.optJSONArray(VCLDidDocument.KeyVerificationMethod)?.length() ?: 0) == 0
+        ) {
+            VCLResult.Failure(
+                ErrorTaxonomy.toDidResolutionError(
+                    VCLError(message = "public jwk not found for kid"),
+                    requestKind = requestKind,
+                    requestDid = requestDid,
+                )
+            )
+        } else {
+            null
+        }
+
+    private fun missingJwtKidError(requestDid: String?, requestKind: String): VCLError =
+        requestValidationError(
+            VCLError(message = "JWT kid is missing"),
+            requestDid,
+            requestKind,
+        )
+
+    private fun unresolvedJwtKeyError(
+        kid: String,
+        requestDid: String?,
+        requestKind: String,
+    ): VCLError =
+        requestValidationError(
+            VCLError(message = "public jwk not found for kid: $kid"),
+            requestDid,
+            requestKind,
+        )
+}

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/VCLAsyncResult.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/usecases/VCLAsyncResult.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.velocitycareerlabs.impl.data.usecases
+
+import io.velocitycareerlabs.api.entities.VCLResult
+
+internal typealias VCLAsyncResult<T> = ((VCLResult<T>) -> Unit) -> Unit
+
+internal fun <T> vclAsyncResult(block: ((VCLResult<T>) -> Unit) -> Unit): VCLAsyncResult<T> = block
+
+internal fun <T> vclAsyncSuccess(value: T): VCLAsyncResult<T> =
+    { completion -> completion(VCLResult.Success(value)) }
+
+internal fun <T, U> VCLAsyncResult<T>.then(next: (T) -> VCLAsyncResult<U>): VCLAsyncResult<U> =
+    { completion ->
+        this { result ->
+            when (result) {
+                is VCLResult.Failure -> completion(VCLResult.Failure(result.error))
+                is VCLResult.Success -> next(result.data)(completion)
+            }
+        }
+    }
+
+internal fun <T, U> VCLAsyncResult<T>.map(transform: (T) -> U): VCLAsyncResult<U> =
+    then { value -> vclAsyncSuccess(transform(value)) }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.kt
@@ -34,12 +34,14 @@ internal class CredentialManifestByDeepLinkVerifierImpl: CredentialManifestByDee
                 onError(
                     errorCode = VCLErrorCode.MismatchedRequestIssuerDid,
                     errorMessage = "credential manifest: ${credentialManifest.jwt.encodedJwt} \ndidDocument: $didDocument",
+                    requestUri = deepLink.requestUri,
                     completionBlock = completionBlock
                 )
             }
         }  ?: run {
             onError(
                 errorMessage = "DID not found in deep link: ${deepLink?.value}",
+                requestUri = deepLink?.requestUri,
                 completionBlock = completionBlock
             )
         }
@@ -48,11 +50,12 @@ internal class CredentialManifestByDeepLinkVerifierImpl: CredentialManifestByDee
     private fun onError(
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
         errorMessage: String,
+        requestUri: String?,
         completionBlock: (VCLResult<Boolean>) -> Unit
 
     ) {
         VCLLog.e(TAG, errorMessage)
-        val error = VCLError(errorCode = errorCode.value, message = errorMessage)
+        val error = VCLError(errorCode = errorCode.value, message = errorMessage, requestUri = requestUri)
         completionBlock(
             (VCLResult.Failure(
                 ErrorTaxonomy.toRequestValidationError(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.kt
@@ -21,27 +21,20 @@ internal class CredentialManifestByDeepLinkVerifierImpl: CredentialManifestByDee
 
     override fun verifyCredentialManifest(
         credentialManifest: VCLCredentialManifest,
-        deepLink: VCLDeepLink?,
+        deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
         completionBlock: (VCLResult<Unit>) -> Unit
     ) {
-        deepLink?.did?.let { deepLinkDid ->
-            if (didDocument.id == credentialManifest.issuerId && didDocument.id == deepLinkDid ||
-                didDocument.alsoKnownAs.contains(credentialManifest.issuerId) && didDocument.alsoKnownAs.contains(deepLinkDid)
-            ) {
-                completionBlock(VCLResult.Success(Unit))
-            } else {
-                onError(
-                    errorCode = VCLErrorCode.MismatchedRequestIssuerDid,
-                    errorMessage = "credential manifest: ${credentialManifest.jwt.encodedJwt} \ndidDocument: $didDocument",
-                    requestUri = deepLink.requestUri,
-                    completionBlock = completionBlock
-                )
-            }
-        }  ?: run {
+        val deepLinkDid = deepLink.did!!
+        if (didDocument.id == credentialManifest.issuerId && didDocument.id == deepLinkDid ||
+            didDocument.alsoKnownAs.contains(credentialManifest.issuerId) && didDocument.alsoKnownAs.contains(deepLinkDid)
+        ) {
+            completionBlock(VCLResult.Success(Unit))
+        } else {
             onError(
-                errorMessage = "DID not found in deep link: ${deepLink?.value}",
-                requestUri = deepLink?.requestUri,
+                errorCode = VCLErrorCode.MismatchedRequestIssuerDid,
+                errorMessage = "credential manifest: ${credentialManifest.jwt.encodedJwt} \ndidDocument: $didDocument",
+                requestUri = deepLink.requestUri,
                 completionBlock = completionBlock
             )
         }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/CredentialManifestByDeepLinkVerifierImpl.kt
@@ -23,13 +23,13 @@ internal class CredentialManifestByDeepLinkVerifierImpl: CredentialManifestByDee
         credentialManifest: VCLCredentialManifest,
         deepLink: VCLDeepLink?,
         didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<Boolean>) -> Unit
+        completionBlock: (VCLResult<Unit>) -> Unit
     ) {
         deepLink?.did?.let { deepLinkDid ->
             if (didDocument.id == credentialManifest.issuerId && didDocument.id == deepLinkDid ||
                 didDocument.alsoKnownAs.contains(credentialManifest.issuerId) && didDocument.alsoKnownAs.contains(deepLinkDid)
             ) {
-                completionBlock(VCLResult.Success(true))
+                completionBlock(VCLResult.Success(Unit))
             } else {
                 onError(
                     errorCode = VCLErrorCode.MismatchedRequestIssuerDid,
@@ -51,7 +51,7 @@ internal class CredentialManifestByDeepLinkVerifierImpl: CredentialManifestByDee
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
         errorMessage: String,
         requestUri: String?,
-        completionBlock: (VCLResult<Boolean>) -> Unit
+        completionBlock: (VCLResult<Unit>) -> Unit
 
     ) {
         VCLLog.e(TAG, errorMessage)

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
@@ -23,14 +23,14 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
         presentationRequest: VCLPresentationRequest,
         deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<Boolean>) -> Unit
+        completionBlock: (VCLResult<Unit>) -> Unit
     ) {
         deepLink.did?.let { deepLinkDid ->
             if (
                 isDidBoundToDidDocument(presentationRequest.iss, didDocument) &&
                 isDidBoundToDidDocument(deepLinkDid, didDocument)
             ) {
-                completionBlock(VCLResult.Success(true))
+                completionBlock(VCLResult.Success(Unit))
             } else {
                 onError(
                     errorCode = VCLErrorCode.MismatchedPresentationRequestInspectorDid,
@@ -53,7 +53,7 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
         errorMessage: String,
         requestUri: String?,
-        completionBlock: (VCLResult<Boolean>) -> Unit
+        completionBlock: (VCLResult<Unit>) -> Unit
 
     ) {
         VCLLog.e(TAG, errorMessage)

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
@@ -25,25 +25,20 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
         didDocument: VCLDidDocument,
         completionBlock: (VCLResult<Unit>) -> Unit
     ) {
-        deepLink.did?.let { deepLinkDid ->
-            if (
-                isDidBoundToDidDocument(presentationRequest.iss, didDocument) &&
-                isDidBoundToDidDocument(deepLinkDid, didDocument)
-            ) {
-                completionBlock(VCLResult.Success(Unit))
-            } else {
-                onError(
-                    errorCode = VCLErrorCode.MismatchedPresentationRequestInspectorDid,
-                    errorMessage = "presentation request: ${presentationRequest.jwt.encodedJwt} \ndid document: $didDocument",
-                    requestUri = deepLink.requestUri,
-                    completionBlock = completionBlock
-                )
-            }
-        } ?: onError(
-            errorMessage = "DID not found in deep link: ${deepLink.value}",
-            requestUri = deepLink.requestUri,
-            completionBlock = completionBlock,
-        )
+        val deepLinkDid = deepLink.did!!
+        if (
+            isDidBoundToDidDocument(presentationRequest.iss, didDocument) &&
+            isDidBoundToDidDocument(deepLinkDid, didDocument)
+        ) {
+            completionBlock(VCLResult.Success(Unit))
+        } else {
+            onError(
+                errorCode = VCLErrorCode.MismatchedPresentationRequestInspectorDid,
+                errorMessage = "presentation request: ${presentationRequest.jwt.encodedJwt} \ndid document: $didDocument",
+                requestUri = deepLink.requestUri,
+                completionBlock = completionBlock
+            )
+        }
     }
 
     private fun isDidBoundToDidDocument(requestDid: String, didDocument: VCLDidDocument): Boolean =

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/data/verifiers/PresentationRequestByDeepLinkVerifierImpl.kt
@@ -35,11 +35,13 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
                 onError(
                     errorCode = VCLErrorCode.MismatchedPresentationRequestInspectorDid,
                     errorMessage = "presentation request: ${presentationRequest.jwt.encodedJwt} \ndid document: $didDocument",
+                    requestUri = deepLink.requestUri,
                     completionBlock = completionBlock
                 )
             }
         } ?: onError(
             errorMessage = "DID not found in deep link: ${deepLink.value}",
+            requestUri = deepLink.requestUri,
             completionBlock = completionBlock,
         )
     }
@@ -50,11 +52,12 @@ internal class PresentationRequestByDeepLinkVerifierImpl: PresentationRequestByD
     private fun onError(
         errorCode: VCLErrorCode = VCLErrorCode.SdkError,
         errorMessage: String,
+        requestUri: String?,
         completionBlock: (VCLResult<Boolean>) -> Unit
 
     ) {
         VCLLog.e(TAG, errorMessage)
-        val error = VCLError(errorCode = errorCode.value, message = errorMessage)
+        val error = VCLError(errorCode = errorCode.value, message = errorMessage, requestUri = requestUri)
         completionBlock(
             (VCLResult.Failure(
                 ErrorTaxonomy.toRequestValidationError(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/domain/verifiers/CredentialManifestByDeepLinkVerifier.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/domain/verifiers/CredentialManifestByDeepLinkVerifier.kt
@@ -14,7 +14,7 @@ import io.velocitycareerlabs.api.entities.VCLResult
 internal interface CredentialManifestByDeepLinkVerifier {
     fun verifyCredentialManifest(
         credentialManifest: VCLCredentialManifest,
-        deepLink: VCLDeepLink?,
+        deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
         completionBlock: (VCLResult<Unit>) -> Unit
     )

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/domain/verifiers/CredentialManifestByDeepLinkVerifier.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/domain/verifiers/CredentialManifestByDeepLinkVerifier.kt
@@ -16,6 +16,6 @@ internal interface CredentialManifestByDeepLinkVerifier {
         credentialManifest: VCLCredentialManifest,
         deepLink: VCLDeepLink?,
         didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<Boolean>) -> Unit
+        completionBlock: (VCLResult<Unit>) -> Unit
     )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/domain/verifiers/PresentationRequestByDeepLinkVerifier.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/domain/verifiers/PresentationRequestByDeepLinkVerifier.kt
@@ -16,6 +16,6 @@ internal interface PresentationRequestByDeepLinkVerifier {
         presentationRequest: VCLPresentationRequest,
         deepLink: VCLDeepLink,
         didDocument: VCLDidDocument,
-        completionBlock: (VCLResult<Boolean>) -> Unit
+        completionBlock: (VCLResult<Unit>) -> Unit
     )
 }

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/utils/ErrorTaxonomy.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/utils/ErrorTaxonomy.kt
@@ -68,11 +68,7 @@ internal object ErrorTaxonomy {
 
     fun toRegistrationCheckError(error: VCLError, requestKind: String, requestDid: String?): VCLError =
         error.toTaxonomyError(
-            taxonomyCode = if (error.isConnectivityFailure()) {
-                VCLErrorCode.ConnectivityFailure
-            } else {
-                requestKind.notRegisteredCode()
-            },
+            taxonomyCode = registrationCheckCode(error, requestKind),
             context = TaxonomyContext(
                 validationPhase = PhaseRegistrationCheck,
                 requestDid = requestDid,
@@ -121,6 +117,7 @@ internal object ErrorTaxonomy {
         VCLErrorCode.ClientRequestRejected.value,
         VCLErrorCode.IssuerDidUnresolvable.value,
         VCLErrorCode.VerifierDidUnresolvable.value,
+        VCLErrorCode.RegistrationCheckInconclusive.value,
         VCLErrorCode.IssuerNotRegistered.value,
         VCLErrorCode.VerifierNotRegistered.value,
         VCLErrorCode.IssuerRequestInvalid.value,
@@ -166,6 +163,13 @@ internal object ErrorTaxonomy {
             error.isConnectivityFailure() -> VCLErrorCode.ConnectivityFailure
             error.statusCode == 401 || error.statusCode == 403 -> VCLErrorCode.ClientRequestUnauthorized
             else -> VCLErrorCode.ClientRequestRejected
+        }
+
+    private fun registrationCheckCode(error: VCLError, requestKind: String): VCLErrorCode =
+        when {
+            error.isConnectivityFailure() -> VCLErrorCode.ConnectivityFailure
+            error.statusCode == 404 -> requestKind.notRegisteredCode()
+            else -> VCLErrorCode.RegistrationCheckInconclusive
         }
 
     private data class TaxonomyContext(

--- a/VCL/src/main/java/io/velocitycareerlabs/impl/utils/ErrorTaxonomy.kt
+++ b/VCL/src/main/java/io/velocitycareerlabs/impl/utils/ErrorTaxonomy.kt
@@ -90,7 +90,12 @@ internal object ErrorTaxonomy {
             ),
         )
 
-    fun toRequestValidationError(error: VCLError, requestKind: String, requestDid: String?): VCLError =
+    fun toRequestValidationError(
+        error: VCLError,
+        requestKind: String,
+        requestDid: String?,
+        requestUri: String? = null,
+    ): VCLError =
         error.toTaxonomyError(
             taxonomyCode = if (error.isConnectivityFailure()) {
                 VCLErrorCode.ConnectivityFailure
@@ -100,6 +105,7 @@ internal object ErrorTaxonomy {
             context = TaxonomyContext(
                 validationPhase = PhaseRequestValidation,
                 requestDid = requestDid,
+                requestUri = requestUri,
                 requestKind = requestKind,
             ),
         )

--- a/VCL/src/test/java/io/velocitycareerlabs/infrastructure/resources/valid/PresentationSubmissionMocks.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/infrastructure/resources/valid/PresentationSubmissionMocks.kt
@@ -19,8 +19,8 @@ class PresentationSubmissionMocks {
             pushUrl = "https://devservices.velocitycareerlabs.io/api/push-gateway",
             pushToken = "if0123asd129smw321"
         )
-        const val PresentationSubmissionResultJson =
-            "{\"token\":\"u7yLD8KS2eTEqkg9aRQE\",\"exchange\":{\"id\":\"64131231\",\"type\":\"DISCLOSURE\",\"disclosureComplete\":true,\"exchangeComplete\":true}}"
+        val PresentationSubmissionResultJson =
+            "{\"token\":\"${TokenMocks.TokenStr1}\",\"exchange\":{\"id\":\"64131231\",\"type\":\"DISCLOSURE\",\"disclosureComplete\":true,\"exchangeComplete\":true}}"
         val PresentationRequest = VCLPresentationRequest(
             jwt = JwtServiceMocks.JWT,
             verifiedProfile = VCLVerifiedProfile("{}".toJsonObject()!!),

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.velocitycareerlabs.backwardscompatibility
+package io.velocitycareerlabs.integration
 
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
@@ -74,7 +74,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
             val missingDidDeepLink = VCLDeepLink("velocity-network://${entryPoint.schemePath}")
 
             listOf(VCLDeepLink("not a url"), missingDidDeepLink).forEach { deepLink ->
-                val error = getEntryPointError(entryPoint, deepLink)
+                val error = getLegacyEntryPointError(entryPoint, deepLink)
 
                 assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
                 assertTrue(error.message!!.contains("did was not found"))
@@ -88,7 +88,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
             val deepLink = VCLDeepLink(
                 "https://example.com/${entryPoint.schemePath}?${entryPoint.didParam}=did:example:entity"
             )
-            val error = getEntryPointError(entryPoint, deepLink)
+            val error = getLegacyEntryPointError(entryPoint, deepLink)
 
             assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
             assertEquals(entryPoint.endpointNullMessage, error.message)
@@ -116,7 +116,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
             val deepLink = VCLDeepLink(
                 "velocity-network://${entryPoint.schemePath}?${entryPoint.didParam}=did:example:entity"
             )
-            val error = getEntryPointError(entryPoint, deepLink)
+            val error = getLegacyEntryPointError(entryPoint, deepLink)
 
             assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
             assertEquals(entryPoint.endpointNullMessage, error.message)
@@ -125,7 +125,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
 
     @Test
     fun missingDirectRequestDidPreservesLegacyDidMessage() {
-        val error = getCredentialManifestDescriptorError(
+        val error = getLegacyCredentialManifestDescriptorError(
             descriptor = credentialManifestDescriptorByService(did = ""),
         )
 
@@ -145,8 +145,8 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
                     "request_uri=ftp%3A%2F%2Fexample.com%2Frequest" +
                     "&${entryPoint.didParam}=did:example:entity"
             )
-            val malformedRequestUri = getEntryPointError(entryPoint, malformedRequestUriDeepLink)
-            val disallowedSchemeRequestUri = getEntryPointError(entryPoint, disallowedSchemeDeepLink)
+            val malformedRequestUri = getLegacyEntryPointError(entryPoint, malformedRequestUriDeepLink)
+            val disallowedSchemeRequestUri = getLegacyEntryPointError(entryPoint, disallowedSchemeDeepLink)
 
             assertEquals(VCLErrorCode.SdkError.value, malformedRequestUri.errorCode)
             assertTrue(malformedRequestUri.message!!.contains("no protocol: not-a-url"))
@@ -160,7 +160,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun transportFailureReturnsSdkErrorWithNetworkStatusOnly() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(
                     requestFailure = UnknownHostException("offline"),
@@ -177,7 +177,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     fun requestEndpoint401And403PreserveHttpStatusAndPayloadErrorCode() {
         entryPoints.forEach { entryPoint ->
             listOf(401, 403).forEach { statusCode ->
-                val error = getEntryPointError(
+                val error = getLegacyEntryPointError(
                     entryPoint,
                     router = defaultRouter(entryPoint).copy(
                         requestStatusCode = statusCode,
@@ -202,7 +202,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
 
         entryPoints.forEach { entryPoint ->
             listOf(400, 404, 409, 410, 422, 500, 502).forEach { statusCode ->
-                val error = getEntryPointError(
+                val error = getLegacyEntryPointError(
                     entryPoint,
                     router = defaultRouter(entryPoint).copy(
                         requestStatusCode = statusCode,
@@ -220,7 +220,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun plainTextRequestEndpointRejectionsDefaultToSdkErrorWithHttpStatusAndPayloadMessage() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(
                     requestStatusCode = 500,
@@ -243,7 +243,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
         }.toString()
 
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(
                     requestStatusCode = 422,
@@ -262,7 +262,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun emptyRequestEndpointResponseReturnsSdkError() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(requestPayload = ""),
             )
@@ -274,7 +274,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun malformedRequestEndpointResponseReturnsSdkError() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(requestPayload = "not json"),
             )
@@ -286,7 +286,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun missingExpectedRequestFieldsReturnSdkErrorAfterEmptyJwtIsDecoded() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(requestPayload = "{}"),
             )
@@ -300,7 +300,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun didResolutionNetworkFailurePropagatesSdkErrorAndStatusFromNetwork() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(
                     didDocumentStatusCode = 404,
@@ -318,7 +318,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun invalidDidDocumentShapeReturnsSdkErrorAtRequestValidation() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(didDocumentPayload = "not json"),
             )
@@ -331,7 +331,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun missingDidDocumentVerificationMaterialReturnsSdkError() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(didDocumentPayload = "{}"),
             )
@@ -346,7 +346,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun verifiedProfileLookupFailurePropagatesNetworkErrorDetails() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(
                     verifiedProfileStatusCode = 404,
@@ -366,7 +366,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     @Test
     fun emptyVerifiedProfileFailsServiceTypeVerification() {
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(verifiedProfilePayload = "{}"),
             )
@@ -384,7 +384,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
                 EntryPoint.Issuing -> VerifiedProfileMocks.VerifiedProfileInspectorJsonStr
                 EntryPoint.Presentation -> VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1
             }
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 router = defaultRouter(entryPoint).copy(verifiedProfilePayload = wrongServiceProfile),
             )
@@ -401,7 +401,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     fun duplicateQueryParamsUseLastDidValueAtSdkEntryPoint() {
         entryPoints.forEach { entryPoint ->
             val router = defaultRouter(entryPoint)
-            val vcl = initializedVcl(router)
+            val vcl = initializedVcl(router, errorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Legacy)
             val deepLink = VCLDeepLink(
                 "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
                     "&${entryPoint.didParam}=did:example:first&${entryPoint.didParam}=${entryPoint.lastDid}"
@@ -429,7 +429,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
                 "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
                     "&${entryPoint.didParam}=not-a-did"
             )
-            val error = getEntryPointError(entryPoint, deepLink)
+            val error = getLegacyEntryPointError(entryPoint, deepLink)
 
             assertEquals(entryPoint.mismatchErrorCode, error.errorCode)
         }
@@ -442,7 +442,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
                 "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
                     "&${entryPoint.didParam}=did:example:wrong"
             )
-            val error = getEntryPointError(entryPoint, deepLink)
+            val error = getLegacyEntryPointError(entryPoint, deepLink)
 
             assertEquals(entryPoint.mismatchErrorCode, error.errorCode)
         }
@@ -456,7 +456,7 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
         )
 
         entryPoints.forEach { entryPoint ->
-            val error = getEntryPointError(
+            val error = getLegacyEntryPointError(
                 entryPoint,
                 jwtVerificationResult = VCLResult.Failure(expectedError),
             )
@@ -466,318 +466,4 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
         }
     }
 
-    private enum class EntryPoint {
-        Issuing,
-        Presentation,
-    }
-
-    private val entryPoints = listOf(EntryPoint.Issuing, EntryPoint.Presentation)
-
-    private val EntryPoint.defaultDeepLink: VCLDeepLink
-        get() = when (this) {
-            EntryPoint.Issuing -> DeepLinkMocks.CredentialManifestDeepLinkDevNet
-            EntryPoint.Presentation -> DeepLinkMocks.PresentationRequestDeepLinkDevNet
-        }
-
-    private val EntryPoint.endpointNullMessage: String
-        get() = when (this) {
-            EntryPoint.Issuing -> "credentialManifestDescriptor.endpoint = null"
-            EntryPoint.Presentation -> "presentationRequestDescriptor.endpoint = null"
-        }
-
-    private val EntryPoint.mismatchErrorCode: String
-        get() = when (this) {
-            EntryPoint.Issuing -> VCLErrorCode.MismatchedRequestIssuerDid.value
-            EntryPoint.Presentation -> VCLErrorCode.MismatchedPresentationRequestInspectorDid.value
-        }
-
-    private val EntryPoint.didParam: String
-        get() = when (this) {
-            EntryPoint.Issuing -> "issuerDid"
-            EntryPoint.Presentation -> "inspectorDid"
-        }
-
-    private val EntryPoint.schemePath: String
-        get() = when (this) {
-            EntryPoint.Issuing -> "issue"
-            EntryPoint.Presentation -> "inspect"
-        }
-
-    private val EntryPoint.encodedRequestUri: String
-        get() = when (this) {
-            EntryPoint.Issuing -> DeepLinkMocks.CredentialManifestRequestUriStr
-            EntryPoint.Presentation -> DeepLinkMocks.PresentationRequestRequestUriStr
-        }
-
-    private val EntryPoint.lastDid: String get() = "did:example:last"
-
-    private fun defaultRouter(entryPoint: EntryPoint): BaselineHttpRouter =
-        when (entryPoint) {
-            EntryPoint.Issuing -> BaselineHttpRouter()
-            EntryPoint.Presentation -> BaselineHttpRouter(
-                verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
-                requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
-            )
-        }
-
-    private fun getEntryPointError(
-        entryPoint: EntryPoint,
-        deepLink: VCLDeepLink = entryPoint.defaultDeepLink,
-        router: BaselineHttpRouter = defaultRouter(entryPoint),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError =
-        when (entryPoint) {
-            EntryPoint.Issuing -> getCredentialManifestError(deepLink, router, jwtVerificationResult)
-            EntryPoint.Presentation -> getPresentationRequestError(deepLink, router, jwtVerificationResult)
-        }
-
-    private fun getCredentialManifestError(
-        deepLink: VCLDeepLink,
-        router: BaselineHttpRouter = BaselineHttpRouter(),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError {
-        val vcl = initializedVcl(router, jwtVerificationResult)
-        return awaitCredentialManifestError(vcl, credentialManifestDescriptor(deepLink))
-    }
-
-    private fun getCredentialManifestDescriptorError(
-        descriptor: VCLCredentialManifestDescriptor,
-        router: BaselineHttpRouter = BaselineHttpRouter(),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError {
-        val vcl = initializedVcl(router, jwtVerificationResult)
-        return awaitCredentialManifestError(vcl, descriptor)
-    }
-
-    private fun getPresentationRequestError(
-        deepLink: VCLDeepLink,
-        router: BaselineHttpRouter = BaselineHttpRouter(
-            verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
-            requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
-        ),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError {
-        val vcl = initializedVcl(router, jwtVerificationResult)
-        return awaitPresentationRequestError(vcl, presentationDescriptor(deepLink))
-    }
-
-    private fun initializedVcl(
-        router: BaselineHttpRouter,
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLImpl {
-        val vcl = VCLImpl(router::connectionFor)
-        var initError: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.initialize(
-            context = ApplicationProvider.getApplicationContext(),
-            initializationDescriptor = VCLInitializationDescriptor(
-                cacheSequence = cacheSequence.incrementAndGet(),
-                errorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Legacy,
-                cryptoServicesDescriptor = VCLCryptoServicesDescriptor(
-                    cryptoServiceType = VCLCryptoServiceType.Injected,
-                    injectedCryptoServicesDescriptor = VCLInjectedCryptoServicesDescriptor(
-                        keyService = VCLKeyServiceMock(),
-                        jwtSignService = VCLJwtSignServiceMock(),
-                        jwtVerifyService = FixedJwtVerifyService(jwtVerificationResult),
-                    ),
-                ),
-            ),
-            successHandler = {
-                latch.countDown()
-            },
-            errorHandler = {
-                initError = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        assertNull("VCL initialization failed: ${initError?.toJsonObject()}", initError)
-        return vcl
-    }
-
-    private fun awaitCredentialManifestError(
-        vcl: VCLImpl,
-        descriptor: VCLCredentialManifestDescriptor,
-    ): VCLError {
-        var result: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.getCredentialManifest(
-            credentialManifestDescriptor = descriptor,
-            successHandler = { manifest ->
-                fail("Credential manifest failure expected: $manifest")
-            },
-            errorHandler = {
-                result = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        return result ?: error("getCredentialManifest did not invoke errorHandler")
-    }
-
-    private fun awaitPresentationRequestError(
-        vcl: VCLImpl,
-        descriptor: VCLPresentationRequestDescriptor,
-    ): VCLError {
-        var result: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.getPresentationRequest(
-            presentationRequestDescriptor = descriptor,
-            successHandler = { presentationRequest ->
-                fail("Presentation request failure expected: $presentationRequest")
-            },
-            errorHandler = {
-                result = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        return result ?: error("getPresentationRequest did not invoke errorHandler")
-    }
-
-    private fun drainMainThreadUntil(latch: CountDownLatch) {
-        val deadline = System.currentTimeMillis() + 5_000
-        while (latch.count > 0 && System.currentTimeMillis() < deadline) {
-            shadowOf(android.os.Looper.getMainLooper()).idle()
-            latch.await(20, TimeUnit.MILLISECONDS)
-        }
-        shadowOf(android.os.Looper.getMainLooper()).idle()
-        assertEquals("Timed out waiting for callback", 0, latch.count)
-    }
-
-    private fun credentialManifestDescriptor(deepLink: VCLDeepLink) =
-        VCLCredentialManifestDescriptorByDeepLink(
-            deepLink = deepLink,
-            didJwk = DidJwkMocks.DidJwk,
-        )
-
-    private fun credentialManifestDescriptorByService(
-        did: String = DeepLinkMocks.IssuerDid,
-    ) =
-        VCLCredentialManifestDescriptorByService(
-            service = VCLService(
-                JSONObject()
-                    .put(VCLService.KeyId, "${DeepLinkMocks.IssuerDid}#credential-agent-issuer-1")
-                    .put(VCLService.KeyType, "VelocityCredentialAgentIssuer_v1.0")
-                    .put(VCLService.KeyServiceEndpoint, DeepLinkMocks.CredentialManifestRequestDecodedUriStr)
-            ),
-            issuingType = VCLIssuingType.Career,
-            didJwk = DidJwkMocks.DidJwk,
-            did = did,
-        )
-
-    private fun presentationDescriptor(deepLink: VCLDeepLink) =
-        VCLPresentationRequestDescriptor(
-            deepLink = deepLink,
-            didJwk = DidJwkMocks.DidJwk,
-        )
-
-    private class FixedJwtVerifyService(
-        private val result: VCLResult<Boolean>,
-    ) : VCLJwtVerifyService {
-        override fun verify(
-            jwt: VCLJwt,
-            publicJwk: VCLPublicJwk,
-            remoteCryptoServicesToken: VCLToken?,
-            completionBlock: (VCLResult<Boolean>) -> Unit,
-        ) {
-            completionBlock(result)
-        }
-    }
-
-    private data class BaselineHttpRouter(
-        private val verifiedProfilePayload: String = VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1,
-        private val verifiedProfileStatusCode: Int = 200,
-        private val verifiedProfileContentType: String? = Request.ContentTypeApplicationJson,
-        private val requestPayload: String = CredentialManifestMocks.CredentialManifest1,
-        private val requestStatusCode: Int = 200,
-        private val requestContentType: String? = Request.ContentTypeApplicationJson,
-        private val requestFailure: Exception? = null,
-        private val didDocumentPayload: String = DidDocumentMocks.DidDocumentMockStr,
-        private val didDocumentStatusCode: Int = 200,
-        private val didDocumentContentType: String? = Request.ContentTypeApplicationJson,
-    ) {
-        val requestedEndpoints: MutableList<String> = Collections.synchronizedList(mutableListOf())
-
-        fun connectionFor(request: Request): HttpURLConnection {
-            requestedEndpoints.add(request.endpoint)
-            if (isSdkRequestEndpoint(request.endpoint)) {
-                requestFailure?.let { throw it }
-                if (request.endpoint.startsWith("not-a-url")) {
-                    throw MalformedURLException("no protocol: ${request.endpoint}")
-                }
-                if (request.endpoint.startsWith("ftp://")) {
-                    throw MalformedURLException("unknown protocol: ftp")
-                }
-            }
-            val route = routeFor(request.endpoint)
-            return FakeHttpURLConnection(
-                url = URL(request.endpoint),
-                responseCodeValue = route.statusCode,
-                contentTypeValue = route.contentType,
-                payload = route.payload,
-            )
-        }
-
-        private fun routeFor(endpoint: String): Route =
-            when {
-                endpoint.contains("/reference/countries") ->
-                    Route(200, Request.ContentTypeApplicationJson, CountriesMocks.CountriesJson)
-                endpoint.contains("/api/v0.6/credential-types") ->
-                    Route(200, Request.ContentTypeApplicationJson, CredentialTypesMocks.CredentialTypesJson)
-                endpoint.contains("/schemas/") ->
-                    Route(200, Request.ContentTypeApplicationJson, CredentialTypeSchemaMocks.CredentialTypeSchemaJson)
-                endpoint.contains("/verified-profile") ->
-                    Route(verifiedProfileStatusCode, verifiedProfileContentType, verifiedProfilePayload)
-                endpoint.contains("/resolve-did/") ->
-                    Route(didDocumentStatusCode, didDocumentContentType, didDocumentPayload)
-                isSdkRequestEndpoint(endpoint) ->
-                    Route(requestStatusCode, requestContentType, requestPayload)
-                else ->
-                    error("Unhandled HTTP endpoint in baseline test: $endpoint")
-            }
-
-        private fun isSdkRequestEndpoint(endpoint: String): Boolean =
-            endpoint.contains("get-credential-manifest") ||
-                endpoint.contains("get-presentation-request") ||
-                endpoint.startsWith("not-a-url") ||
-                endpoint.startsWith("ftp://")
-    }
-
-    private data class Route(
-        val statusCode: Int,
-        val contentType: String?,
-        val payload: String,
-    )
-
-    private class FakeHttpURLConnection(
-        url: URL,
-        private val responseCodeValue: Int,
-        private val contentTypeValue: String?,
-        private val payload: String,
-    ) : HttpURLConnection(url) {
-        override fun connect() = Unit
-
-        override fun disconnect() = Unit
-
-        override fun usingProxy() = false
-
-        override fun getResponseCode(): Int = responseCodeValue
-
-        override fun getContentType(): String? = contentTypeValue
-
-        override fun getErrorStream(): InputStream? =
-            if (responseCodeValue >= HTTP_OK && responseCodeValue <= 299) {
-                null
-            } else {
-                ByteArrayInputStream(payload.toByteArray())
-            }
-
-        override fun getInputStream(): InputStream =
-            ByteArrayInputStream(payload.toByteArray())
-    }
-
-    private companion object {
-        val cacheSequence = AtomicInteger(1000)
-    }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyBackwardCompatibilityBaselineTest.kt
@@ -124,16 +124,6 @@ internal class ErrorTaxonomyBackwardCompatibilityBaselineTest {
     }
 
     @Test
-    fun missingDirectRequestDidPreservesLegacyDidMessage() {
-        val error = getLegacyCredentialManifestDescriptorError(
-            descriptor = credentialManifestDescriptorByService(did = ""),
-        )
-
-        assertEquals(VCLErrorCode.SdkError.value, error.errorCode)
-        assertTrue(error.message!!.contains("did was not found"))
-    }
-
-    @Test
     fun malformedAndDisallowedRequestUriValuesReachTransportAsRawEndpointText() {
         entryPoints.forEach { entryPoint ->
             val malformedRequestUriDeepLink = VCLDeepLink(

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -92,7 +92,7 @@ internal class ErrorTaxonomyContractTest {
     // Link validation -> invalid_link
 
     @Test
-    fun malformedLinksAndMissingRequiredParamsReturnSdkError() {
+    fun malformedLinksAndMissingRequiredParamsReturnInvalidLink() {
         entryPoints.forEach { entryPoint ->
             val missingDidDeepLink = VCLDeepLink("velocity-network://${entryPoint.schemePath}")
 
@@ -137,7 +137,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun unsupportedSchemeWithKnownQueryParamsReturnsNullEndpointSdkError() {
+    fun unsupportedSchemeWithKnownQueryParamsReturnsInvalidLink() {
         entryPoints.forEach { entryPoint ->
             val deepLink = VCLDeepLink(
                 "https://example.com/${entryPoint.schemePath}?${entryPoint.didParam}=did:example:entity"
@@ -215,7 +215,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun missingRequestUriProducesEndpointNullSdkErrors() {
+    fun missingRequestUriProducesInvalidLink() {
         entryPoints.forEach { entryPoint ->
             val deepLink = VCLDeepLink(
                 "velocity-network://${entryPoint.schemePath}?${entryPoint.didParam}=did:example:entity"
@@ -319,7 +319,7 @@ internal class ErrorTaxonomyContractTest {
     // Client request fetch -> client_request_unauthorized / client_request_rejected
 
     @Test
-    fun transportFailureReturnsSdkErrorWithNetworkStatusOnly() {
+    fun transportFailureReturnsConnectivityFailureWithNetworkStatusOnly() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -407,7 +407,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun plainTextRequestEndpointRejectionsDefaultToSdkErrorWithHttpStatusAndPayloadMessage() {
+    fun plainTextRequestEndpointRejectionsReturnClientRequestRejectedWithHttpStatusAndPayloadMessage() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -435,7 +435,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun jsonRequestEndpointRejectionsWithoutErrorCodeDefaultToSdkError() {
+    fun jsonRequestEndpointRejectionsWithoutErrorCodeReturnClientRequestRejected() {
         val payloadWithoutErrorCode = JSONObject(ErrorMocks.Payload).apply {
             remove(VCLError.KeyErrorCode)
         }.toString()
@@ -468,7 +468,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun emptyRequestEndpointResponseReturnsSdkError() {
+    fun emptyRequestEndpointResponseReturnsClientRequestRejected() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -488,7 +488,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun malformedRequestEndpointResponseReturnsSdkError() {
+    fun malformedRequestEndpointResponseReturnsClientRequestRejected() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -584,7 +584,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun didResolutionNetworkFailurePropagatesSdkErrorAndStatusFromNetwork() {
+    fun didResolutionNetworkFailureReturnsDidUnresolvableWithStatusFromNetwork() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -634,7 +634,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun missingDidDocumentVerificationMaterialReturnsSdkError() {
+    fun missingDidDocumentVerificationMaterialReturnsDidUnresolvable() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -784,7 +784,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun wrongIssuerOrVerifierServiceTypeReturnsSdkErrorWithVerificationStatus() {
+    fun wrongIssuerOrVerifierServiceTypeReturnsRequestUnauthorizedWithVerificationStatus() {
         entryPoints.forEach { entryPoint ->
             val wrongServiceProfile = when (entryPoint) {
                 EntryPoint.Issuing -> VerifiedProfileMocks.VerifiedProfileInspectorJsonStr
@@ -859,7 +859,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun jwtVerificationFailurePropagatesSdkErrorFromInjectedJwtService() {
+    fun jwtVerificationFailureReturnsRequestInvalidFromInjectedJwtService() {
         val expectedError = VCLError(
             errorCode = VCLErrorCode.SdkError.value,
             message = "jwt signature verification failed",

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -528,27 +528,27 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun malformedIssuingRequestJwtReturnsRequestInvalid() {
-        val error = getEntryPointError(
-            EntryPoint.Issuing,
-            router = BaselineHttpRouter(
-                requestPayload = JSONObject()
-                    .put(VCLCredentialManifest.KeyIssuingRequest, "not-a-jwt")
-                    .toString(),
-            ),
-        )
+    fun malformedRequestJwtReturnsRequestInvalid() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    requestPayload = entryPoint.requestPayloadForJwt("not-a-jwt"),
+                ),
+            )
 
-        assertDiagnostics(
-            expected = EntryPoint.Issuing.expectedDiagnostics(
-                errorCode = VCLErrorCode.IssuerRequestInvalid.value,
-                sourceErrorCode = VCLErrorCode.SdkError.value,
-                validationPhase = "request_validation",
-                requestDid = DeepLinkMocks.IssuerDid,
-                requestKind = ErrorTaxonomy.RequestKindIssuing,
-            ),
-            actual = error,
-        )
-        assertEquals("Malformed JWT", error.message)
+            assertDiagnostics(
+                expected = entryPoint.expectedDiagnostics(
+                    errorCode = entryPoint.requestInvalidErrorCode,
+                    sourceErrorCode = VCLErrorCode.SdkError.value,
+                    validationPhase = "request_validation",
+                    requestDid = entryPoint.requestDid,
+                    requestKind = entryPoint.requestKind,
+                ),
+                actual = error,
+            )
+            assertEquals("Malformed JWT", error.message)
+        }
     }
 
     @Test

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -271,6 +271,63 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
+    fun invalidDirectRequestEndpointReturnsInvalidLink() {
+        val endpoint = "ftp://example.com/request"
+        val vcl = initializedVcl(defaultRouter(EntryPoint.Issuing))
+        val error = awaitCredentialManifestError(
+            vcl,
+            credentialManifestDescriptorByService(endpoint = endpoint),
+        )
+
+        assertDiagnostics(
+            expected = EntryPoint.Issuing.expectedDiagnostics(
+                errorCode = VCLErrorCode.InvalidLink.value,
+                sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
+                validationPhase = "link_validation",
+                requestUri = endpoint,
+            ),
+            actual = error,
+        )
+    }
+
+    @Test
+    fun missingDirectRequestEndpointReturnsInvalidLink() {
+        val vcl = initializedVcl(defaultRouter(EntryPoint.Issuing))
+        val error = awaitCredentialManifestError(
+            vcl,
+            credentialManifestDescriptorByService(endpoint = ""),
+        )
+
+        assertDiagnostics(
+            expected = EntryPoint.Issuing.expectedDiagnostics(
+                errorCode = VCLErrorCode.InvalidLink.value,
+                sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
+                validationPhase = "link_validation",
+                requestUri = "",
+            ),
+            actual = error,
+        )
+    }
+
+    @Test
+    fun missingDirectRequestDidReturnsInvalidLink() {
+        val vcl = initializedVcl(defaultRouter(EntryPoint.Issuing))
+        val error = awaitCredentialManifestError(
+            vcl,
+            credentialManifestDescriptorByService(did = ""),
+        )
+
+        assertDiagnostics(
+            expected = EntryPoint.Issuing.expectedDiagnostics(
+                errorCode = VCLErrorCode.InvalidLink.value,
+                validationPhase = "link_validation",
+            ),
+            actual = error,
+        )
+        assertTrue(error.message!!.contains("did was not found"))
+    }
+
+    @Test
     fun malformedDidSyntaxReturnsInvalidLink() {
         entryPoints.forEach { entryPoint ->
             listOf("not-a-did", "did:", "did:example", "did:Example:entity").forEach { did ->
@@ -581,6 +638,20 @@ internal class ErrorTaxonomyContractTest {
             actual = error,
         )
         assertEquals("Missing issuing_request", error.message)
+    }
+
+    @Test
+    fun credentialManifestByServiceSucceedsWithoutDeepLinkVerification() {
+        val router = defaultRouter(EntryPoint.Issuing)
+        val vcl = initializedVcl(router)
+        val credentialManifest = awaitCredentialManifest(
+            vcl,
+            credentialManifestDescriptorByService(),
+        )
+
+        assertNull(credentialManifest.deepLink)
+        assertEquals(DeepLinkMocks.IssuerDid, credentialManifest.did)
+        assertTrue(router.requestedEndpoints.any { it.contains("get-credential-manifest") })
     }
 
     @Test

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -192,6 +192,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = entryPoint.legacyMismatchErrorCode,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = deepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -366,6 +367,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = entryPoint.legacyMismatchErrorCode,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = deepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -525,7 +527,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun emptyRequestEndpointResponseReturnsClientRequestRejected() {
+    fun emptyRequestEndpointResponseReturnsRequestInvalid() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -534,18 +536,27 @@ internal class ErrorTaxonomyContractTest {
 
             assertDiagnostics(
                 expected = entryPoint.expectedDiagnostics(
-                    errorCode = VCLErrorCode.ClientRequestRejected.value,
+                    errorCode = entryPoint.requestInvalidErrorCode,
                     sourceErrorCode = VCLErrorCode.SdkError.value,
-                    validationPhase = "client_request_fetch",
+                    validationPhase = "request_validation",
+                    requestDid = entryPoint.requestDid,
                     requestUri = entryPoint.defaultDeepLink.requestUri,
+                    requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
+            )
+            assertEquals(
+                when (entryPoint) {
+                    EntryPoint.Issuing -> "Missing issuing_request"
+                    EntryPoint.Presentation -> "Missing presentation_request"
+                },
+                error.message,
             )
         }
     }
 
     @Test
-    fun malformedRequestEndpointResponseReturnsClientRequestRejected() {
+    fun malformedRequestEndpointResponseReturnsRequestInvalid() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -554,12 +565,21 @@ internal class ErrorTaxonomyContractTest {
 
             assertDiagnostics(
                 expected = entryPoint.expectedDiagnostics(
-                    errorCode = VCLErrorCode.ClientRequestRejected.value,
+                    errorCode = entryPoint.requestInvalidErrorCode,
                     sourceErrorCode = VCLErrorCode.SdkError.value,
-                    validationPhase = "client_request_fetch",
+                    validationPhase = "request_validation",
+                    requestDid = entryPoint.requestDid,
                     requestUri = entryPoint.defaultDeepLink.requestUri,
+                    requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
+            )
+            assertEquals(
+                when (entryPoint) {
+                    EntryPoint.Issuing -> "Missing issuing_request"
+                    EntryPoint.Presentation -> "Missing presentation_request"
+                },
+                error.message,
             )
         }
     }
@@ -578,6 +598,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = VCLErrorCode.SdkError.value,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = entryPoint.defaultDeepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -608,6 +629,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = VCLErrorCode.SdkError.value,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = entryPoint.defaultDeepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -633,6 +655,7 @@ internal class ErrorTaxonomyContractTest {
                 sourceErrorCode = VCLErrorCode.SdkError.value,
                 validationPhase = "request_validation",
                 requestDid = EntryPoint.Issuing.requestDid,
+                requestUri = EntryPoint.Issuing.defaultDeepLink.requestUri,
                 requestKind = EntryPoint.Issuing.requestKind,
             ),
             actual = error,
@@ -766,6 +789,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = VCLErrorCode.SdkError.value,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = entryPoint.defaultDeepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -793,6 +817,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = VCLErrorCode.SdkError.value,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = entryPoint.defaultDeepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -899,6 +924,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = entryPoint.legacyMismatchErrorCode,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = deepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -922,6 +948,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = entryPoint.legacyMismatchErrorCode,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = deepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
@@ -948,6 +975,7 @@ internal class ErrorTaxonomyContractTest {
                     sourceErrorCode = VCLErrorCode.SdkError.value,
                     validationPhase = "request_validation",
                     requestDid = entryPoint.requestDid,
+                    requestUri = entryPoint.defaultDeepLink.requestUri,
                     requestKind = entryPoint.requestKind,
                 ),
                 actual = error,

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -508,7 +508,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun missingExpectedRequestFieldsReturnSdkErrorAfterEmptyJwtIsDecoded() {
+    fun missingExpectedRequestFieldsReturnRequestInvalid() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
                 entryPoint,
@@ -517,12 +517,20 @@ internal class ErrorTaxonomyContractTest {
 
             assertDiagnostics(
                 expected = entryPoint.expectedDiagnostics(
-                    errorCode = VCLErrorCode.ClientRequestRejected.value,
+                    errorCode = entryPoint.requestInvalidErrorCode,
                     sourceErrorCode = VCLErrorCode.SdkError.value,
-                    validationPhase = "client_request_fetch",
-                    requestUri = entryPoint.defaultDeepLink.requestUri,
+                    validationPhase = "request_validation",
+                    requestDid = entryPoint.requestDid,
+                    requestKind = entryPoint.requestKind,
                 ),
                 actual = error,
+            )
+            assertEquals(
+                when (entryPoint) {
+                    EntryPoint.Issuing -> "Missing issuing_request"
+                    EntryPoint.Presentation -> "Missing presentation_request"
+                },
+                error.message,
             )
         }
     }
@@ -572,7 +580,7 @@ internal class ErrorTaxonomyContractTest {
             ),
             actual = error,
         )
-        assertEquals("Malformed JWT", error.message)
+        assertEquals("Missing issuing_request", error.message)
     }
 
     @Test

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -552,7 +552,7 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun emptyIssuingRequestReturnsSdkErrorAfterRequestFetch() {
+    fun emptyIssuingRequestReturnsRequestInvalid() {
         val error = getEntryPointError(
             EntryPoint.Issuing,
             router = BaselineHttpRouter(
@@ -564,14 +564,15 @@ internal class ErrorTaxonomyContractTest {
 
         assertDiagnostics(
             expected = EntryPoint.Issuing.expectedDiagnostics(
-                errorCode = VCLErrorCode.ClientRequestRejected.value,
+                errorCode = VCLErrorCode.IssuerRequestInvalid.value,
                 sourceErrorCode = VCLErrorCode.SdkError.value,
-                validationPhase = "client_request_fetch",
-                requestUri = EntryPoint.Issuing.defaultDeepLink.requestUri,
+                validationPhase = "request_validation",
+                requestDid = EntryPoint.Issuing.requestDid,
+                requestKind = EntryPoint.Issuing.requestKind,
             ),
             actual = error,
         )
-        assertEquals("Missing issuing_request", error.message)
+        assertEquals("Malformed JWT", error.message)
     }
 
     @Test

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -881,6 +881,84 @@ internal class ErrorTaxonomyContractTest {
         }
     }
 
+    @Test
+    fun verifiedProfileServerErrorReturnsRegistrationCheckInconclusive() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    verifiedProfileStatusCode = 500,
+                    verifiedProfilePayload = """{"message":"profile lookup failed","errorCode":"sdk_error"}""",
+                    verifiedProfileContentType = Request.ContentTypeApplicationJson,
+                ),
+            )
+
+            assertDiagnostics(
+                expected = entryPoint.expectedDiagnostics(
+                    errorCode = VCLErrorCode.RegistrationCheckInconclusive.value,
+                    sourceErrorCode = VCLErrorCode.SdkError.value,
+                    statusCode = 500,
+                    validationPhase = "registration_check",
+                    payload = """{"message":"profile lookup failed","errorCode":"sdk_error"}""",
+                    requestKind = entryPoint.requestKind,
+                    requestDid = entryPoint.requestDid,
+                ),
+                actual = error,
+            )
+            assertEquals("profile lookup failed", error.message)
+        }
+    }
+
+    @Test
+    fun unexpectedVerifiedProfileClientErrorReturnsRegistrationCheckInconclusive() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    verifiedProfileStatusCode = 400,
+                    verifiedProfilePayload = """{"message":"bad profile lookup","errorCode":"sdk_error"}""",
+                    verifiedProfileContentType = Request.ContentTypeApplicationJson,
+                ),
+            )
+
+            assertDiagnostics(
+                expected = entryPoint.expectedDiagnostics(
+                    errorCode = VCLErrorCode.RegistrationCheckInconclusive.value,
+                    sourceErrorCode = VCLErrorCode.SdkError.value,
+                    statusCode = 400,
+                    validationPhase = "registration_check",
+                    payload = """{"message":"bad profile lookup","errorCode":"sdk_error"}""",
+                    requestKind = entryPoint.requestKind,
+                    requestDid = entryPoint.requestDid,
+                ),
+                actual = error,
+            )
+            assertEquals("bad profile lookup", error.message)
+        }
+    }
+
+    @Test
+    fun malformedVerifiedProfileSuccessReturnsRegistrationCheckInconclusive() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(verifiedProfilePayload = "not json"),
+            )
+
+            assertDiagnostics(
+                expected = entryPoint.expectedDiagnostics(
+                    errorCode = VCLErrorCode.RegistrationCheckInconclusive.value,
+                    sourceErrorCode = VCLErrorCode.SdkError.value,
+                    validationPhase = "registration_check",
+                    requestKind = entryPoint.requestKind,
+                    requestDid = entryPoint.requestDid,
+                ),
+                actual = error,
+            )
+            assertTrue(error.message!!.isNotBlank())
+        }
+    }
+
     // Request authorization -> issuer_request_unauthorized / verifier_request_unauthorized
 
     @Test

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -639,6 +639,33 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
+    fun requestJwtWithoutIssReturnsRequestInvalid() {
+        entryPoints.forEach { entryPoint ->
+            val error = getEntryPointError(
+                entryPoint,
+                router = defaultRouter(entryPoint).copy(
+                    requestPayload = entryPoint.requestPayloadForJwt(
+                        encodedJwtWithoutIss(entryPoint.defaultRequestJwt)
+                    ),
+                ),
+            )
+
+            assertDiagnostics(
+                expected = entryPoint.expectedDiagnostics(
+                    errorCode = entryPoint.requestInvalidErrorCode,
+                    sourceErrorCode = VCLErrorCode.SdkError.value,
+                    validationPhase = "request_validation",
+                    requestDid = entryPoint.requestDid,
+                    requestUri = entryPoint.defaultDeepLink.requestUri,
+                    requestKind = entryPoint.requestKind,
+                ),
+                actual = error,
+            )
+            assertEquals("Missing iss", error.message)
+        }
+    }
+
+    @Test
     fun emptyIssuingRequestReturnsRequestInvalid() {
         val error = getEntryPointError(
             EntryPoint.Issuing,

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyContractTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.velocitycareerlabs.backwardscompatibility
+package io.velocitycareerlabs.integration
 
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
@@ -47,6 +47,7 @@ import io.velocitycareerlabs.impl.domain.repositories.PresentationRequestReposit
 import io.velocitycareerlabs.impl.domain.repositories.ResolveDidDocumentRepository
 import io.velocitycareerlabs.impl.domain.verifiers.CredentialManifestByDeepLinkVerifier
 import io.velocitycareerlabs.impl.domain.verifiers.PresentationRequestByDeepLinkVerifier
+import io.velocitycareerlabs.impl.utils.ErrorTaxonomy
 import io.velocitycareerlabs.impl.utils.ProfileServiceTypeVerifier
 import io.velocitycareerlabs.impl.utils.VelocityDeepLinkValidator
 import io.velocitycareerlabs.infrastructure.resources.EmptyExecutor
@@ -267,75 +268,6 @@ internal class ErrorTaxonomyContractTest {
                 actual = disallowedSchemeRequestUri,
             )
         }
-    }
-
-    @Test
-    fun invalidDirectRequestEndpointReturnsInvalidLink() {
-        val endpoint = "ftp://example.com/request"
-        val error = getCredentialManifestDescriptorError(
-            descriptor = credentialManifestDescriptorByService(endpoint = endpoint),
-        )
-
-        assertDiagnostics(
-            expected = EntryPoint.Issuing.expectedDiagnostics(
-                errorCode = VCLErrorCode.InvalidLink.value,
-                sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
-                validationPhase = "link_validation",
-                requestUri = endpoint,
-            ),
-            actual = error,
-        )
-    }
-
-    @Test
-    fun missingDirectRequestEndpointReturnsInvalidLink() {
-        val error = getCredentialManifestDescriptorError(
-            descriptor = credentialManifestDescriptorByService(endpoint = null),
-        )
-
-        assertDiagnostics(
-            expected = EntryPoint.Issuing.expectedDiagnostics(
-                errorCode = VCLErrorCode.InvalidLink.value,
-                sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
-                validationPhase = "link_validation",
-                requestUri = "",
-            ),
-            actual = error,
-        )
-    }
-
-    @Test
-    fun repositoryNullEndpointFallbacksReturnInvalidLinkDiagnostics() {
-        mapOf(
-            EntryPoint.Issuing to getCredentialManifestRepositoryNullEndpointError(),
-            EntryPoint.Presentation to getPresentationRequestRepositoryNullEndpointError(),
-        ).forEach { (entryPoint, error) ->
-            assertDiagnostics(
-                expected = entryPoint.expectedDiagnostics(
-                    errorCode = VCLErrorCode.InvalidLink.value,
-                    sourceErrorCode = VelocityDeepLinkValidator.SourceInvalidOrMissingRequestEndpoint,
-                    validationPhase = "link_validation",
-                ),
-                actual = error,
-            )
-            assertTrue(error.message!!.contains("endpoint = null"))
-        }
-    }
-
-    @Test
-    fun missingDirectRequestDidReturnsInvalidLink() {
-        val error = getCredentialManifestDescriptorError(
-            descriptor = credentialManifestDescriptorByService(did = ""),
-        )
-
-        assertDiagnostics(
-            expected = EntryPoint.Issuing.expectedDiagnostics(
-                errorCode = VCLErrorCode.InvalidLink.value,
-                validationPhase = "link_validation",
-            ),
-            actual = error,
-        )
-        assertTrue(error.message!!.contains("did was not found"))
     }
 
     @Test
@@ -596,9 +528,33 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
+    fun malformedIssuingRequestJwtReturnsRequestInvalid() {
+        val error = getEntryPointError(
+            EntryPoint.Issuing,
+            router = BaselineHttpRouter(
+                requestPayload = JSONObject()
+                    .put(VCLCredentialManifest.KeyIssuingRequest, "not-a-jwt")
+                    .toString(),
+            ),
+        )
+
+        assertDiagnostics(
+            expected = EntryPoint.Issuing.expectedDiagnostics(
+                errorCode = VCLErrorCode.IssuerRequestInvalid.value,
+                sourceErrorCode = VCLErrorCode.SdkError.value,
+                validationPhase = "request_validation",
+                requestDid = DeepLinkMocks.IssuerDid,
+                requestKind = ErrorTaxonomy.RequestKindIssuing,
+            ),
+            actual = error,
+        )
+        assertEquals("Malformed JWT", error.message)
+    }
+
+    @Test
     fun emptyIssuingRequestReturnsSdkErrorAfterRequestFetch() {
-        val error = getCredentialManifestDescriptorError(
-            descriptor = credentialManifestDescriptorByService(),
+        val error = getEntryPointError(
+            EntryPoint.Issuing,
             router = BaselineHttpRouter(
                 requestPayload = JSONObject()
                     .put(VCLCredentialManifest.KeyIssuingRequest, "")
@@ -611,26 +567,12 @@ internal class ErrorTaxonomyContractTest {
                 errorCode = VCLErrorCode.ClientRequestRejected.value,
                 sourceErrorCode = VCLErrorCode.SdkError.value,
                 validationPhase = "client_request_fetch",
-                requestUri = credentialManifestDescriptorByService().endpoint,
+                requestUri = EntryPoint.Issuing.defaultDeepLink.requestUri,
             ),
             actual = error,
         )
         assertEquals("Missing issuing_request", error.message)
     }
-
-    @Test
-    fun credentialManifestByServiceSucceedsWithoutDeepLinkVerification() {
-        val vcl = initializedVcl(BaselineHttpRouter())
-        val credentialManifest = awaitCredentialManifest(
-            vcl = vcl,
-            descriptor = credentialManifestDescriptorByService(),
-        )
-
-        assertNull(credentialManifest.deepLink)
-        assertEquals(DeepLinkMocks.IssuerDid, credentialManifest.did)
-    }
-
-    // DID resolution -> issuer_did_unresolvable / verifier_did_unresolvable
 
     @Test
     fun didResolutionNetworkFailurePropagatesSdkErrorAndStatusFromNetwork() {
@@ -780,36 +722,6 @@ internal class ErrorTaxonomyContractTest {
     }
 
     @Test
-    fun responseVerificationFalseReturnsRequestInvalid() {
-        listOf(
-            Triple(
-                EntryPoint.Issuing,
-                getCredentialManifestUseCaseVerificationFalseError(),
-                "Failed to verify credentialManifest jwt",
-            ),
-            Triple(
-                EntryPoint.Presentation,
-                getPresentationRequestUseCaseVerificationFalseError(),
-                "Failed to verify:",
-            ),
-        ).forEach { (entryPoint, error, message) ->
-            assertDiagnostics(
-                expected = entryPoint.expectedDiagnostics(
-                    errorCode = entryPoint.requestInvalidErrorCode,
-                    sourceErrorCode = VCLErrorCode.SdkError.value,
-                    validationPhase = "request_validation",
-                    requestDid = entryPoint.requestDid,
-                    requestKind = entryPoint.requestKind,
-                ),
-                actual = error,
-            )
-            assertTrue(error.message!!.contains(message))
-        }
-    }
-
-    // Registration / profile check -> issuer_not_registered / verifier_not_registered
-
-    @Test
     fun verifiedProfileLookupFailurePropagatesNetworkErrorDetails() {
         entryPoints.forEach { entryPoint ->
             val error = getEntryPointError(
@@ -895,21 +807,11 @@ internal class ErrorTaxonomyContractTest {
     fun duplicateQueryParamsUseLastDidValueAtSdkEntryPoint() {
         entryPoints.forEach { entryPoint ->
             val router = defaultRouter(entryPoint)
-            val vcl = initializedVcl(router)
             val deepLink = VCLDeepLink(
                 "velocity-network://${entryPoint.schemePath}?request_uri=${entryPoint.encodedRequestUri}" +
                     "&${entryPoint.didParam}=did:example:first&${entryPoint.didParam}=${entryPoint.lastDid}"
             )
-            val error = when (entryPoint) {
-                EntryPoint.Issuing -> awaitCredentialManifestError(
-                    vcl,
-                    credentialManifestDescriptor(deepLink),
-                )
-                EntryPoint.Presentation -> awaitPresentationRequestError(
-                    vcl,
-                    presentationDescriptor(deepLink),
-                )
-            }
+            val error = getEntryPointError(entryPoint, deepLink, router)
 
             assertDiagnostics(
                 expected = entryPoint.expectedDiagnostics(
@@ -974,599 +876,4 @@ internal class ErrorTaxonomyContractTest {
         }
     }
 
-    private enum class EntryPoint(
-        val defaultDeepLink: VCLDeepLink,
-        val requestKind: String,
-        val requestDid: String,
-        val legacyMismatchErrorCode: String,
-        val requestInvalidErrorCode: String,
-        val didUnresolvableErrorCode: String,
-        val notRegisteredErrorCode: String,
-        val requestUnauthorizedErrorCode: String,
-        val didParam: String,
-        val otherDidParam: String,
-        val schemePath: String,
-        val encodedRequestUri: String,
-    ) {
-        Issuing(
-            defaultDeepLink = DeepLinkMocks.CredentialManifestDeepLinkDevNet,
-            requestKind = "issuing_request",
-            requestDid = DeepLinkMocks.IssuerDid,
-            legacyMismatchErrorCode = VCLErrorCode.MismatchedRequestIssuerDid.value,
-            requestInvalidErrorCode = VCLErrorCode.IssuerRequestInvalid.value,
-            didUnresolvableErrorCode = VCLErrorCode.IssuerDidUnresolvable.value,
-            notRegisteredErrorCode = VCLErrorCode.IssuerNotRegistered.value,
-            requestUnauthorizedErrorCode = VCLErrorCode.IssuerRequestUnauthorized.value,
-            didParam = "issuerDid",
-            otherDidParam = "inspectorDid",
-            schemePath = "issue",
-            encodedRequestUri = DeepLinkMocks.CredentialManifestRequestUriStr,
-        ),
-        Presentation(
-            defaultDeepLink = DeepLinkMocks.PresentationRequestDeepLinkDevNet,
-            requestKind = "presentation_request",
-            requestDid = DeepLinkMocks.InspectorDid,
-            legacyMismatchErrorCode = VCLErrorCode.MismatchedPresentationRequestInspectorDid.value,
-            requestInvalidErrorCode = VCLErrorCode.VerifierRequestInvalid.value,
-            didUnresolvableErrorCode = VCLErrorCode.VerifierDidUnresolvable.value,
-            notRegisteredErrorCode = VCLErrorCode.VerifierNotRegistered.value,
-            requestUnauthorizedErrorCode = VCLErrorCode.VerifierRequestUnauthorized.value,
-            didParam = "inspectorDid",
-            otherDidParam = "issuerDid",
-            schemePath = "inspect",
-            encodedRequestUri = DeepLinkMocks.PresentationRequestRequestUriStr,
-        ),
-    }
-
-    private val entryPoints = EntryPoint.entries
-
-    private data class ErrorDiagnostics(
-        val payload: String? = null,
-        val error: String? = null,
-        val errorCode: String,
-        val sourceErrorCode: String? = null,
-        val requestId: String? = null,
-        val statusCode: Int? = null,
-        val validationPhase: String? = null,
-        val requestDid: String? = null,
-        val requestUri: String? = null,
-        val requestKind: String? = null,
-    )
-
-    private fun assertDiagnostics(
-        expected: ErrorDiagnostics,
-        actual: VCLError,
-    ) {
-        assertEquals(expected.canonicalizePayload(), actual.toDiagnostics())
-    }
-
-    private fun VCLError.toDiagnostics() = ErrorDiagnostics(
-        payload = payload?.canonicalJsonOrSelf(),
-        error = error,
-        errorCode = errorCode,
-        sourceErrorCode = sourceErrorCode,
-        requestId = requestId,
-        statusCode = statusCode,
-        validationPhase = validationPhase,
-        requestDid = requestDid,
-        requestUri = requestUri,
-        requestKind = requestKind,
-    )
-
-    private fun ErrorDiagnostics.canonicalizePayload() =
-        copy(payload = payload?.canonicalJsonOrSelf())
-
-    private fun String.canonicalJsonOrSelf(): String =
-        runCatching { JSONObject(this).toString() }.getOrDefault(this)
-
-    private fun EntryPoint.expectedDiagnostics(
-        errorCode: String,
-        payload: String? = null,
-        error: String? = null,
-        sourceErrorCode: String? = null,
-        requestId: String? = null,
-        statusCode: Int? = null,
-        validationPhase: String? = null,
-        requestDid: String? = null,
-        requestUri: String? = null,
-        requestKind: String? = this.requestKind,
-    ) = ErrorDiagnostics(
-        payload = payload,
-        error = error,
-        errorCode = errorCode,
-        sourceErrorCode = sourceErrorCode,
-        requestId = requestId,
-        statusCode = statusCode,
-        validationPhase = validationPhase,
-        requestDid = requestDid,
-        requestUri = requestUri,
-        requestKind = requestKind,
-    )
-
-    private val EntryPoint.lastDid: String get() = "did:example:last"
-
-    private fun simpleRequestUri(): String =
-        URLEncoder.encode("https://example.com/request", "UTF-8")
-
-    private val EntryPoint.defaultRequestJwt: String
-        get() = when (this) {
-            EntryPoint.Issuing -> CredentialManifestMocks.JwtCredentialManifest1
-            EntryPoint.Presentation -> PresentationRequestMocks.EncodedPresentationRequest
-        }
-
-    private fun EntryPoint.requestPayloadForJwt(encodedJwt: String): String =
-        when (this) {
-            EntryPoint.Issuing -> JSONObject().put(VCLCredentialManifest.KeyIssuingRequest, encodedJwt)
-            EntryPoint.Presentation -> JSONObject().put(VCLPresentationRequest.KeyPresentationRequest, encodedJwt)
-        }.toString()
-
-    private fun encodedJwtWithoutKid(encodedJwt: String): String {
-        val parts = encodedJwt.split(".")
-        val headerJson = JSONObject(String(Base64.getUrlDecoder().decode(parts[0])))
-        headerJson.remove(VCLJwt.KeyKid)
-        return encodedJwtWithHeader(encodedJwt, headerJson)
-    }
-
-    private fun encodedJwtWithKid(encodedJwt: String, kid: String): String {
-        val parts = encodedJwt.split(".")
-        val headerJson = JSONObject(String(Base64.getUrlDecoder().decode(parts[0])))
-        headerJson.put(VCLJwt.KeyKid, kid)
-        return encodedJwtWithHeader(encodedJwt, headerJson)
-    }
-
-    private fun encodedJwtWithHeader(encodedJwt: String, headerJson: JSONObject): String {
-        val parts = encodedJwt.split(".")
-        val encodedHeader = Base64.getUrlEncoder()
-            .withoutPadding()
-            .encodeToString(headerJson.toString().toByteArray(Charsets.UTF_8))
-        return listOf(encodedHeader, parts[1], parts[2]).joinToString(".")
-    }
-
-    private fun defaultRouter(entryPoint: EntryPoint): BaselineHttpRouter =
-        when (entryPoint) {
-            EntryPoint.Issuing -> BaselineHttpRouter()
-            EntryPoint.Presentation -> BaselineHttpRouter(
-                verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
-                requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
-            )
-        }
-
-    private fun getEntryPointError(
-        entryPoint: EntryPoint,
-        deepLink: VCLDeepLink = entryPoint.defaultDeepLink,
-        router: BaselineHttpRouter = defaultRouter(entryPoint),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError =
-        when (entryPoint) {
-            EntryPoint.Issuing -> getCredentialManifestError(deepLink, router, jwtVerificationResult)
-            EntryPoint.Presentation -> getPresentationRequestError(deepLink, router, jwtVerificationResult)
-        }
-
-    private fun getCredentialManifestError(
-        deepLink: VCLDeepLink,
-        router: BaselineHttpRouter = BaselineHttpRouter(),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError {
-        val vcl = initializedVcl(router, jwtVerificationResult)
-        return awaitCredentialManifestError(vcl, credentialManifestDescriptor(deepLink))
-    }
-
-    private fun getCredentialManifestDescriptorError(
-        descriptor: VCLCredentialManifestDescriptor,
-        router: BaselineHttpRouter = BaselineHttpRouter(),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError {
-        val vcl = initializedVcl(router, jwtVerificationResult)
-        return awaitCredentialManifestError(vcl, descriptor)
-    }
-
-    private fun getPresentationRequestError(
-        deepLink: VCLDeepLink,
-        router: BaselineHttpRouter = BaselineHttpRouter(
-            verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
-            requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
-        ),
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLError {
-        val vcl = initializedVcl(router, jwtVerificationResult)
-        return awaitPresentationRequestError(vcl, presentationDescriptor(deepLink))
-    }
-
-    private fun getCredentialManifestUseCaseVerificationFalseError(): VCLError {
-        var result: VCLError? = null
-        CredentialManifestUseCaseImpl(
-            credentialManifestRepository = object : CredentialManifestRepository {
-                override fun getCredentialManifest(
-                    credentialManifestDescriptor: VCLCredentialManifestDescriptor,
-                    completionBlock: (VCLResult<String>) -> Unit,
-                ) {
-                    completionBlock(VCLResult.Success(CredentialManifestMocks.JwtCredentialManifest1))
-                }
-            },
-            resolveDidDocumentRepository = fixedDidDocumentRepository(),
-            jwtServiceRepository = successfulJwtServiceRepository(),
-            credentialManifestByDeepLinkVerifier = object : CredentialManifestByDeepLinkVerifier {
-                override fun verifyCredentialManifest(
-                    credentialManifest: VCLCredentialManifest,
-                    deepLink: VCLDeepLink?,
-                    didDocument: VCLDidDocument,
-                    completionBlock: (VCLResult<Boolean>) -> Unit,
-                ) {
-                    completionBlock(VCLResult.Success(false))
-                }
-            },
-            executor = EmptyExecutor(),
-        ).getCredentialManifest(
-            credentialManifestDescriptor = credentialManifestDescriptor(DeepLinkMocks.CredentialManifestDeepLinkDevNet),
-            verifiedProfile = VCLVerifiedProfile(JSONObject()),
-        ) {
-            it.handleResult(
-                successHandler = { fail("Credential manifest failure expected: $it") },
-                errorHandler = { error -> result = error },
-            )
-        }
-        return result ?: error("getCredentialManifest did not invoke errorHandler")
-    }
-
-    private fun getPresentationRequestUseCaseVerificationFalseError(): VCLError {
-        var result: VCLError? = null
-        PresentationRequestUseCaseImpl(
-            presentationRequestRepository = object : PresentationRequestRepository {
-                override fun getPresentationRequest(
-                    presentationRequestDescriptor: VCLPresentationRequestDescriptor,
-                    completionBlock: (VCLResult<String>) -> Unit,
-                ) {
-                    completionBlock(VCLResult.Success(PresentationRequestMocks.EncodedPresentationRequest))
-                }
-            },
-            resolveDidDocumentRepository = fixedDidDocumentRepository(),
-            jwtServiceRepository = successfulJwtServiceRepository(),
-            presentationRequestByDeepLinkVerifier = object : PresentationRequestByDeepLinkVerifier {
-                override fun verifyPresentationRequest(
-                    presentationRequest: VCLPresentationRequest,
-                    deepLink: VCLDeepLink,
-                    didDocument: VCLDidDocument,
-                    completionBlock: (VCLResult<Boolean>) -> Unit,
-                ) {
-                    completionBlock(VCLResult.Success(false))
-                }
-            },
-            executor = EmptyExecutor(),
-        ).getPresentationRequest(
-            presentationRequestDescriptor = presentationDescriptor(DeepLinkMocks.PresentationRequestDeepLinkDevNet),
-            verifiedProfile = VCLVerifiedProfile(JSONObject()),
-        ) {
-            it.handleResult(
-                successHandler = { fail("Presentation request failure expected: $it") },
-                errorHandler = { error -> result = error },
-            )
-        }
-        return result ?: error("getPresentationRequest did not invoke errorHandler")
-    }
-
-    private fun getCredentialManifestRepositoryNullEndpointError(): VCLError {
-        var result: VCLError? = null
-        CredentialManifestRepositoryImpl(unusedNetworkService()).getCredentialManifest(
-            credentialManifestDescriptor(VCLDeepLink("velocity-network://issue?issuerDid=${EntryPoint.Issuing.requestDid}"))
-        ) {
-            it.handleResult(
-                successHandler = { fail("Credential manifest repository failure expected: $it") },
-                errorHandler = { error -> result = error },
-            )
-        }
-        return result ?: error("getCredentialManifest did not invoke errorHandler")
-    }
-
-    private fun getPresentationRequestRepositoryNullEndpointError(): VCLError {
-        var result: VCLError? = null
-        PresentationRequestRepositoryImpl(unusedNetworkService()).getPresentationRequest(
-            presentationDescriptor(VCLDeepLink("velocity-network://inspect?inspectorDid=${EntryPoint.Presentation.requestDid}"))
-        ) {
-            it.handleResult(
-                successHandler = { fail("Presentation request repository failure expected: $it") },
-                errorHandler = { error -> result = error },
-            )
-        }
-        return result ?: error("getPresentationRequest did not invoke errorHandler")
-    }
-
-    private fun unusedNetworkService() =
-        object : NetworkService {
-            override fun sendRequest(
-                endpoint: String,
-                body: String?,
-                contentType: String,
-                method: Request.HttpMethod,
-                headers: List<Pair<String, String>>?,
-                useCaches: Boolean,
-                completionBlock: (VCLResult<Response>) -> Unit,
-            ) {
-                fail("Network should not be called for null endpoint")
-            }
-        }
-
-    private fun fixedDidDocumentRepository() =
-        object : ResolveDidDocumentRepository {
-            override fun resolveDidDocument(
-                did: String,
-                completionBlock: (VCLResult<VCLDidDocument>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(DidDocumentMocks.DidDocumentMock))
-            }
-        }
-
-    private fun successfulJwtServiceRepository() =
-        object : JwtServiceRepository {
-            override fun decode(
-                encodedJwt: String,
-                completionBlock: (VCLResult<VCLJwt>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(VCLJwt(encodedJwt)))
-            }
-
-            override fun verifyJwt(
-                jwt: VCLJwt,
-                publicJwk: VCLPublicJwk,
-                remoteCryptoServicesToken: VCLToken?,
-                completionBlock: (VCLResult<Boolean>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(true))
-            }
-
-            override fun generateSignedJwt(
-                jwtDescriptor: VCLJwtDescriptor,
-                nonce: String?,
-                didJwk: VCLDidJwk,
-                remoteCryptoServicesToken: VCLToken?,
-                completionBlock: (VCLResult<VCLJwt>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(VCLJwt("")))
-            }
-        }
-
-    private fun initializedVcl(
-        router: BaselineHttpRouter,
-        jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    ): VCLImpl {
-        val vcl = VCLImpl(router::connectionFor)
-        var initError: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.initialize(
-            context = ApplicationProvider.getApplicationContext(),
-            initializationDescriptor = VCLInitializationDescriptor(
-                cacheSequence = cacheSequence.incrementAndGet(),
-                cryptoServicesDescriptor = VCLCryptoServicesDescriptor(
-                    cryptoServiceType = VCLCryptoServiceType.Injected,
-                    injectedCryptoServicesDescriptor = VCLInjectedCryptoServicesDescriptor(
-                        keyService = VCLKeyServiceMock(),
-                        jwtSignService = VCLJwtSignServiceMock(),
-                        jwtVerifyService = FixedJwtVerifyService(jwtVerificationResult),
-                    ),
-                ),
-            ),
-            successHandler = {
-                latch.countDown()
-            },
-            errorHandler = {
-                initError = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        assertNull("VCL initialization failed: ${initError?.toJsonObject()}", initError)
-        return vcl
-    }
-
-    private fun awaitCredentialManifestError(
-        vcl: VCLImpl,
-        descriptor: VCLCredentialManifestDescriptor,
-    ): VCLError {
-        var result: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.getCredentialManifest(
-            credentialManifestDescriptor = descriptor,
-            successHandler = { manifest ->
-                fail("Credential manifest failure expected: $manifest")
-            },
-            errorHandler = {
-                result = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        return result ?: error("getCredentialManifest did not invoke errorHandler")
-    }
-
-    private fun awaitCredentialManifest(
-        vcl: VCLImpl,
-        descriptor: VCLCredentialManifestDescriptor,
-    ): VCLCredentialManifest {
-        var result: VCLCredentialManifest? = null
-        var error: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.getCredentialManifest(
-            credentialManifestDescriptor = descriptor,
-            successHandler = {
-                result = it
-                latch.countDown()
-            },
-            errorHandler = {
-                error = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        error?.let { fail("Credential manifest success expected: $it") }
-        return result ?: error("getCredentialManifest did not invoke successHandler")
-    }
-
-    private fun awaitPresentationRequestError(
-        vcl: VCLImpl,
-        descriptor: VCLPresentationRequestDescriptor,
-    ): VCLError {
-        var result: VCLError? = null
-        val latch = CountDownLatch(1)
-        vcl.getPresentationRequest(
-            presentationRequestDescriptor = descriptor,
-            successHandler = { presentationRequest ->
-                fail("Presentation request failure expected: $presentationRequest")
-            },
-            errorHandler = {
-                result = it
-                latch.countDown()
-            },
-        )
-        drainMainThreadUntil(latch)
-        return result ?: error("getPresentationRequest did not invoke errorHandler")
-    }
-
-    private fun drainMainThreadUntil(latch: CountDownLatch) {
-        val deadline = System.currentTimeMillis() + 5_000
-        while (latch.count > 0 && System.currentTimeMillis() < deadline) {
-            shadowOf(android.os.Looper.getMainLooper()).idle()
-            latch.await(20, TimeUnit.MILLISECONDS)
-        }
-        shadowOf(android.os.Looper.getMainLooper()).idle()
-        assertEquals("Timed out waiting for callback", 0, latch.count)
-    }
-
-    private fun credentialManifestDescriptor(deepLink: VCLDeepLink) =
-        VCLCredentialManifestDescriptorByDeepLink(
-            deepLink = deepLink,
-            didJwk = DidJwkMocks.DidJwk,
-        )
-
-    private fun credentialManifestDescriptorByService(
-        endpoint: String? = DeepLinkMocks.CredentialManifestRequestDecodedUriStr,
-        did: String = DeepLinkMocks.IssuerDid,
-    ) =
-        VCLCredentialManifestDescriptorByService(
-            service = VCLService(
-                JSONObject().apply {
-                    put(VCLService.KeyId, "${DeepLinkMocks.IssuerDid}#credential-agent-issuer-1")
-                    put(VCLService.KeyType, "VelocityCredentialAgentIssuer_v1.0")
-                    if (endpoint != null) {
-                        put(VCLService.KeyServiceEndpoint, endpoint)
-                    }
-                }
-            ),
-            issuingType = VCLIssuingType.Career,
-            didJwk = DidJwkMocks.DidJwk,
-            did = did,
-        )
-
-    private fun presentationDescriptor(deepLink: VCLDeepLink) =
-        VCLPresentationRequestDescriptor(
-            deepLink = deepLink,
-            didJwk = DidJwkMocks.DidJwk,
-        )
-
-    private class FixedJwtVerifyService(
-        private val result: VCLResult<Boolean>,
-    ) : VCLJwtVerifyService {
-        override fun verify(
-            jwt: VCLJwt,
-            publicJwk: VCLPublicJwk,
-            remoteCryptoServicesToken: VCLToken?,
-            completionBlock: (VCLResult<Boolean>) -> Unit,
-        ) {
-            completionBlock(result)
-        }
-    }
-
-    private data class BaselineHttpRouter(
-        private val verifiedProfilePayload: String = VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1,
-        private val verifiedProfileStatusCode: Int = 200,
-        private val verifiedProfileContentType: String? = Request.ContentTypeApplicationJson,
-        private val requestPayload: String = CredentialManifestMocks.CredentialManifest1,
-        private val requestStatusCode: Int = 200,
-        private val requestContentType: String? = Request.ContentTypeApplicationJson,
-        private val requestFailure: Exception? = null,
-        private val didDocumentPayload: String = DidDocumentMocks.DidDocumentMockStr,
-        private val didDocumentStatusCode: Int = 200,
-        private val didDocumentContentType: String? = Request.ContentTypeApplicationJson,
-    ) {
-        val requestedEndpoints: MutableList<String> = Collections.synchronizedList(mutableListOf())
-
-        fun connectionFor(request: Request): HttpURLConnection {
-            requestedEndpoints.add(request.endpoint)
-            if (isSdkRequestEndpoint(request.endpoint)) {
-                requestFailure?.let { throw it }
-                if (request.endpoint.startsWith("not-a-url")) {
-                    throw MalformedURLException("no protocol: ${request.endpoint}")
-                }
-                if (request.endpoint.startsWith("ftp://")) {
-                    throw MalformedURLException("unknown protocol: ftp")
-                }
-            }
-            val route = routeFor(request.endpoint)
-            return FakeHttpURLConnection(
-                url = URL(request.endpoint),
-                responseCodeValue = route.statusCode,
-                contentTypeValue = route.contentType,
-                payload = route.payload,
-            )
-        }
-
-        private fun routeFor(endpoint: String): Route =
-            when {
-                endpoint.contains("/reference/countries") ->
-                    Route(200, Request.ContentTypeApplicationJson, CountriesMocks.CountriesJson)
-                endpoint.contains("/api/v0.6/credential-types") ->
-                    Route(200, Request.ContentTypeApplicationJson, CredentialTypesMocks.CredentialTypesJson)
-                endpoint.contains("/schemas/") ->
-                    Route(200, Request.ContentTypeApplicationJson, CredentialTypeSchemaMocks.CredentialTypeSchemaJson)
-                endpoint.contains("/verified-profile") ->
-                    Route(verifiedProfileStatusCode, verifiedProfileContentType, verifiedProfilePayload)
-                endpoint.contains("/resolve-did/") ->
-                    Route(didDocumentStatusCode, didDocumentContentType, didDocumentPayload)
-                isSdkRequestEndpoint(endpoint) ->
-                    Route(requestStatusCode, requestContentType, requestPayload)
-                else ->
-                    error("Unhandled HTTP endpoint in baseline test: $endpoint")
-            }
-
-        private fun isSdkRequestEndpoint(endpoint: String): Boolean =
-            endpoint.contains("get-credential-manifest") ||
-                endpoint.contains("get-presentation-request") ||
-                endpoint.startsWith("not-a-url") ||
-                endpoint.startsWith("ftp://")
-    }
-
-    private data class Route(
-        val statusCode: Int,
-        val contentType: String?,
-        val payload: String,
-    )
-
-    private class FakeHttpURLConnection(
-        url: URL,
-        private val responseCodeValue: Int,
-        private val contentTypeValue: String?,
-        private val payload: String,
-    ) : HttpURLConnection(url) {
-        override fun connect() = Unit
-
-        override fun disconnect() = Unit
-
-        override fun usingProxy() = false
-
-        override fun getResponseCode(): Int = responseCodeValue
-
-        override fun getContentType(): String? = contentTypeValue
-
-        override fun getErrorStream(): InputStream? =
-            if (responseCodeValue >= HTTP_OK && responseCodeValue <= 299) {
-                null
-            } else {
-                ByteArrayInputStream(payload.toByteArray())
-            }
-
-        override fun getInputStream(): InputStream =
-            ByteArrayInputStream(payload.toByteArray())
-    }
-
-    private companion object {
-        val cacheSequence = AtomicInteger(1000)
-    }
 }

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
@@ -204,12 +204,27 @@ internal fun encodedJwtWithKid(encodedJwt: String, kid: String): String {
     return encodedJwtWithHeader(encodedJwt, headerJson)
 }
 
+internal fun encodedJwtWithoutIss(encodedJwt: String): String {
+    val parts = encodedJwt.split(".")
+    val payloadJson = JSONObject(String(Base64.getUrlDecoder().decode(parts[1])))
+    payloadJson.remove(VCLJwt.KeyIss)
+    return encodedJwtWithPayload(encodedJwt, payloadJson)
+}
+
 internal fun encodedJwtWithHeader(encodedJwt: String, headerJson: JSONObject): String {
     val parts = encodedJwt.split(".")
     val encodedHeader = Base64.getUrlEncoder()
         .withoutPadding()
         .encodeToString(headerJson.toString().toByteArray(Charsets.UTF_8))
     return listOf(encodedHeader, parts[1], parts[2]).joinToString(".")
+}
+
+internal fun encodedJwtWithPayload(encodedJwt: String, payloadJson: JSONObject): String {
+    val parts = encodedJwt.split(".")
+    val encodedPayload = Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(payloadJson.toString().toByteArray(Charsets.UTF_8))
+    return listOf(parts[0], encodedPayload, parts[2]).joinToString(".")
 }
 
 internal fun defaultRouter(entryPoint: EntryPoint): BaselineHttpRouter =

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
@@ -1,0 +1,759 @@
+/**
+ * Copyright 2022 Velocity Career Labs inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.velocitycareerlabs.integration
+
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import io.velocitycareerlabs.api.VCLCryptoServiceType
+import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptor
+import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByDeepLink
+import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByService
+import io.velocitycareerlabs.api.entities.VCLDeepLink
+import io.velocitycareerlabs.api.entities.VCLDidDocument
+import io.velocitycareerlabs.api.entities.VCLDidJwk
+import io.velocitycareerlabs.api.entities.VCLIssuingType
+import io.velocitycareerlabs.api.entities.VCLJwt
+import io.velocitycareerlabs.api.entities.VCLJwtDescriptor
+import io.velocitycareerlabs.api.entities.VCLCredentialManifest
+import io.velocitycareerlabs.api.entities.VCLPresentationRequestDescriptor
+import io.velocitycareerlabs.api.entities.VCLPresentationRequest
+import io.velocitycareerlabs.api.entities.VCLPublicJwk
+import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.VCLService
+import io.velocitycareerlabs.api.entities.VCLToken
+import io.velocitycareerlabs.api.entities.VCLVerifiedProfile
+import io.velocitycareerlabs.api.entities.error.VCLError
+import io.velocitycareerlabs.api.entities.error.VCLErrorCode
+import io.velocitycareerlabs.api.entities.error.VCLStatusCode
+import io.velocitycareerlabs.api.entities.handleResult
+import io.velocitycareerlabs.api.entities.initialization.VCLCryptoServicesDescriptor
+import io.velocitycareerlabs.api.entities.initialization.VCLInjectedCryptoServicesDescriptor
+import io.velocitycareerlabs.api.entities.initialization.VCLInitializationDescriptor
+import io.velocitycareerlabs.api.entities.initialization.VCLErrorCodeCompatibilityMode
+import io.velocitycareerlabs.api.jwt.VCLJwtVerifyService
+import io.velocitycareerlabs.impl.VCLImpl
+import io.velocitycareerlabs.impl.data.infrastructure.network.Request
+import io.velocitycareerlabs.impl.data.infrastructure.network.Response
+import io.velocitycareerlabs.impl.data.repositories.CredentialManifestRepositoryImpl
+import io.velocitycareerlabs.impl.data.repositories.PresentationRequestRepositoryImpl
+import io.velocitycareerlabs.impl.data.usecases.CredentialManifestUseCaseImpl
+import io.velocitycareerlabs.impl.data.usecases.PresentationRequestUseCaseImpl
+import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
+import io.velocitycareerlabs.impl.domain.repositories.CredentialManifestRepository
+import io.velocitycareerlabs.impl.domain.repositories.JwtServiceRepository
+import io.velocitycareerlabs.impl.domain.repositories.PresentationRequestRepository
+import io.velocitycareerlabs.impl.domain.repositories.ResolveDidDocumentRepository
+import io.velocitycareerlabs.impl.domain.verifiers.CredentialManifestByDeepLinkVerifier
+import io.velocitycareerlabs.impl.domain.verifiers.PresentationRequestByDeepLinkVerifier
+import io.velocitycareerlabs.impl.utils.ProfileServiceTypeVerifier
+import io.velocitycareerlabs.impl.utils.VelocityDeepLinkValidator
+import io.velocitycareerlabs.infrastructure.resources.EmptyExecutor
+import io.velocitycareerlabs.infrastructure.resources.valid.CountriesMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialManifestMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypeSchemaMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypesMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.DeepLinkMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.DidDocumentMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.DidJwkMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.ErrorMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.PresentationRequestMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.VCLJwtSignServiceMock
+import io.velocitycareerlabs.infrastructure.resources.valid.VCLKeyServiceMock
+import io.velocitycareerlabs.infrastructure.resources.valid.VerifiedProfileMocks
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.MalformedURLException
+import java.net.URL
+import java.net.URLEncoder
+import java.net.UnknownHostException
+import java.util.Base64
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+internal val entryPoints = EntryPoint.entries
+
+internal enum class EntryPoint(
+    val defaultDeepLink: VCLDeepLink,
+    val requestKind: String,
+    val requestDid: String,
+    val legacyMismatchErrorCode: String,
+    val requestInvalidErrorCode: String,
+    val didUnresolvableErrorCode: String,
+    val notRegisteredErrorCode: String,
+    val requestUnauthorizedErrorCode: String,
+    val didParam: String,
+    val otherDidParam: String,
+    val schemePath: String,
+    val encodedRequestUri: String,
+) {
+    Issuing(
+        defaultDeepLink = DeepLinkMocks.CredentialManifestDeepLinkDevNet,
+        requestKind = "issuing_request",
+        requestDid = DeepLinkMocks.IssuerDid,
+        legacyMismatchErrorCode = VCLErrorCode.MismatchedRequestIssuerDid.value,
+        requestInvalidErrorCode = VCLErrorCode.IssuerRequestInvalid.value,
+        didUnresolvableErrorCode = VCLErrorCode.IssuerDidUnresolvable.value,
+        notRegisteredErrorCode = VCLErrorCode.IssuerNotRegistered.value,
+        requestUnauthorizedErrorCode = VCLErrorCode.IssuerRequestUnauthorized.value,
+        didParam = "issuerDid",
+        otherDidParam = "inspectorDid",
+        schemePath = "issue",
+        encodedRequestUri = DeepLinkMocks.CredentialManifestRequestUriStr,
+    ),
+    Presentation(
+        defaultDeepLink = DeepLinkMocks.PresentationRequestDeepLinkDevNet,
+        requestKind = "presentation_request",
+        requestDid = DeepLinkMocks.InspectorDid,
+        legacyMismatchErrorCode = VCLErrorCode.MismatchedPresentationRequestInspectorDid.value,
+        requestInvalidErrorCode = VCLErrorCode.VerifierRequestInvalid.value,
+        didUnresolvableErrorCode = VCLErrorCode.VerifierDidUnresolvable.value,
+        notRegisteredErrorCode = VCLErrorCode.VerifierNotRegistered.value,
+        requestUnauthorizedErrorCode = VCLErrorCode.VerifierRequestUnauthorized.value,
+        didParam = "inspectorDid",
+        otherDidParam = "issuerDid",
+        schemePath = "inspect",
+        encodedRequestUri = DeepLinkMocks.PresentationRequestRequestUriStr,
+    ),
+}
+
+internal data class ErrorDiagnostics(
+    val payload: String? = null,
+    val error: String? = null,
+    val errorCode: String,
+    val sourceErrorCode: String? = null,
+    val requestId: String? = null,
+    val statusCode: Int? = null,
+    val validationPhase: String? = null,
+    val requestDid: String? = null,
+    val requestUri: String? = null,
+    val requestKind: String? = null,
+)
+
+internal fun assertDiagnostics(
+    expected: ErrorDiagnostics,
+    actual: VCLError,
+) {
+    assertEquals(expected.canonicalizePayload(), actual.toDiagnostics())
+}
+
+internal fun VCLError.toDiagnostics() = ErrorDiagnostics(
+    payload = payload?.canonicalJsonOrSelf(),
+    error = error,
+    errorCode = errorCode,
+    sourceErrorCode = sourceErrorCode,
+    requestId = requestId,
+    statusCode = statusCode,
+    validationPhase = validationPhase,
+    requestDid = requestDid,
+    requestUri = requestUri,
+    requestKind = requestKind,
+)
+
+internal fun ErrorDiagnostics.canonicalizePayload() =
+    copy(payload = payload?.canonicalJsonOrSelf())
+
+internal fun String.canonicalJsonOrSelf(): String =
+    runCatching { JSONObject(this).toString() }.getOrDefault(this)
+
+internal fun EntryPoint.expectedDiagnostics(
+    errorCode: String,
+    payload: String? = null,
+    error: String? = null,
+    sourceErrorCode: String? = null,
+    requestId: String? = null,
+    statusCode: Int? = null,
+    validationPhase: String? = null,
+    requestDid: String? = null,
+    requestUri: String? = null,
+    requestKind: String? = this.requestKind,
+) = ErrorDiagnostics(
+    payload = payload,
+    error = error,
+    errorCode = errorCode,
+    sourceErrorCode = sourceErrorCode,
+    requestId = requestId,
+    statusCode = statusCode,
+    validationPhase = validationPhase,
+    requestDid = requestDid,
+    requestUri = requestUri,
+    requestKind = requestKind,
+)
+
+internal val EntryPoint.lastDid: String get() = "did:example:last"
+
+internal fun simpleRequestUri(): String =
+    URLEncoder.encode("https://example.com/request", "UTF-8")
+
+internal val EntryPoint.defaultRequestJwt: String
+    get() = when (this) {
+        EntryPoint.Issuing -> CredentialManifestMocks.JwtCredentialManifest1
+        EntryPoint.Presentation -> PresentationRequestMocks.EncodedPresentationRequest
+    }
+
+internal fun EntryPoint.requestPayloadForJwt(encodedJwt: String): String =
+    when (this) {
+        EntryPoint.Issuing -> JSONObject().put(VCLCredentialManifest.KeyIssuingRequest, encodedJwt)
+        EntryPoint.Presentation -> JSONObject().put(VCLPresentationRequest.KeyPresentationRequest, encodedJwt)
+    }.toString()
+
+internal fun encodedJwtWithoutKid(encodedJwt: String): String {
+    val parts = encodedJwt.split(".")
+    val headerJson = JSONObject(String(Base64.getUrlDecoder().decode(parts[0])))
+    headerJson.remove(VCLJwt.KeyKid)
+    return encodedJwtWithHeader(encodedJwt, headerJson)
+}
+
+internal fun encodedJwtWithKid(encodedJwt: String, kid: String): String {
+    val parts = encodedJwt.split(".")
+    val headerJson = JSONObject(String(Base64.getUrlDecoder().decode(parts[0])))
+    headerJson.put(VCLJwt.KeyKid, kid)
+    return encodedJwtWithHeader(encodedJwt, headerJson)
+}
+
+internal fun encodedJwtWithHeader(encodedJwt: String, headerJson: JSONObject): String {
+    val parts = encodedJwt.split(".")
+    val encodedHeader = Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(headerJson.toString().toByteArray(Charsets.UTF_8))
+    return listOf(encodedHeader, parts[1], parts[2]).joinToString(".")
+}
+
+internal fun defaultRouter(entryPoint: EntryPoint): BaselineHttpRouter =
+    when (entryPoint) {
+        EntryPoint.Issuing -> BaselineHttpRouter()
+        EntryPoint.Presentation -> BaselineHttpRouter(
+            verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
+            requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
+        )
+    }
+
+internal fun getEntryPointError(
+    entryPoint: EntryPoint,
+    deepLink: VCLDeepLink = entryPoint.defaultDeepLink,
+    router: BaselineHttpRouter = defaultRouter(entryPoint),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Taxonomy,
+): VCLError =
+    when (entryPoint) {
+        EntryPoint.Issuing -> getCredentialManifestError(
+            deepLink,
+            router,
+            jwtVerificationResult,
+            errorCodeCompatibilityMode,
+        )
+        EntryPoint.Presentation -> getPresentationRequestError(
+            deepLink,
+            router,
+            jwtVerificationResult,
+            errorCodeCompatibilityMode,
+        )
+    }
+
+internal fun getLegacyEntryPointError(
+    entryPoint: EntryPoint,
+    deepLink: VCLDeepLink = entryPoint.defaultDeepLink,
+    router: BaselineHttpRouter = defaultRouter(entryPoint),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+): VCLError =
+    getEntryPointError(
+        entryPoint,
+        deepLink,
+        router,
+        jwtVerificationResult,
+        VCLErrorCodeCompatibilityMode.Legacy,
+    )
+
+internal fun getCredentialManifestError(
+    deepLink: VCLDeepLink,
+    router: BaselineHttpRouter = BaselineHttpRouter(),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Taxonomy,
+): VCLError {
+    val vcl = initializedVcl(router, jwtVerificationResult, errorCodeCompatibilityMode)
+    return awaitCredentialManifestError(vcl, credentialManifestDescriptor(deepLink))
+}
+
+internal fun getLegacyCredentialManifestError(
+    deepLink: VCLDeepLink,
+    router: BaselineHttpRouter = BaselineHttpRouter(),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+): VCLError =
+    getCredentialManifestError(
+        deepLink,
+        router,
+        jwtVerificationResult,
+        VCLErrorCodeCompatibilityMode.Legacy,
+    )
+
+internal fun getCredentialManifestDescriptorError(
+    descriptor: VCLCredentialManifestDescriptor,
+    router: BaselineHttpRouter = BaselineHttpRouter(),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Taxonomy,
+): VCLError {
+    val vcl = initializedVcl(router, jwtVerificationResult, errorCodeCompatibilityMode)
+    return awaitCredentialManifestError(vcl, descriptor)
+}
+
+internal fun getLegacyCredentialManifestDescriptorError(
+    descriptor: VCLCredentialManifestDescriptor,
+    router: BaselineHttpRouter = BaselineHttpRouter(),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+): VCLError =
+    getCredentialManifestDescriptorError(
+        descriptor,
+        router,
+        jwtVerificationResult,
+        VCLErrorCodeCompatibilityMode.Legacy,
+    )
+
+internal fun getPresentationRequestError(
+    deepLink: VCLDeepLink,
+    router: BaselineHttpRouter = BaselineHttpRouter(
+        verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
+        requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
+    ),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Taxonomy,
+): VCLError {
+    val vcl = initializedVcl(router, jwtVerificationResult, errorCodeCompatibilityMode)
+    return awaitPresentationRequestError(vcl, presentationDescriptor(deepLink))
+}
+
+internal fun getLegacyPresentationRequestError(
+    deepLink: VCLDeepLink,
+    router: BaselineHttpRouter = BaselineHttpRouter(
+        verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
+        requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
+    ),
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+): VCLError =
+    getPresentationRequestError(
+        deepLink,
+        router,
+        jwtVerificationResult,
+        VCLErrorCodeCompatibilityMode.Legacy,
+    )
+
+internal fun getCredentialManifestUseCaseVerificationFalseError(): VCLError {
+    var result: VCLError? = null
+    CredentialManifestUseCaseImpl(
+        credentialManifestRepository = object : CredentialManifestRepository {
+            override fun getCredentialManifest(
+                credentialManifestDescriptor: VCLCredentialManifestDescriptor,
+                completionBlock: (VCLResult<String>) -> Unit,
+            ) {
+                completionBlock(VCLResult.Success(CredentialManifestMocks.JwtCredentialManifest1))
+            }
+        },
+        resolveDidDocumentRepository = fixedDidDocumentRepository(),
+        jwtServiceRepository = successfulJwtServiceRepository(),
+        credentialManifestByDeepLinkVerifier = object : CredentialManifestByDeepLinkVerifier {
+            override fun verifyCredentialManifest(
+                credentialManifest: VCLCredentialManifest,
+                deepLink: VCLDeepLink?,
+                didDocument: VCLDidDocument,
+                completionBlock: (VCLResult<Boolean>) -> Unit,
+            ) {
+                completionBlock(VCLResult.Success(false))
+            }
+        },
+        executor = EmptyExecutor(),
+    ).getCredentialManifest(
+        credentialManifestDescriptor = credentialManifestDescriptor(DeepLinkMocks.CredentialManifestDeepLinkDevNet),
+        verifiedProfile = VCLVerifiedProfile(JSONObject()),
+    ) {
+        it.handleResult(
+            successHandler = { fail("Credential manifest failure expected: $it") },
+            errorHandler = { error -> result = error },
+        )
+    }
+    return result ?: error("getCredentialManifest did not invoke errorHandler")
+}
+
+internal fun getPresentationRequestUseCaseVerificationFalseError(): VCLError {
+    var result: VCLError? = null
+    PresentationRequestUseCaseImpl(
+        presentationRequestRepository = object : PresentationRequestRepository {
+            override fun getPresentationRequest(
+                presentationRequestDescriptor: VCLPresentationRequestDescriptor,
+                completionBlock: (VCLResult<String>) -> Unit,
+            ) {
+                completionBlock(VCLResult.Success(PresentationRequestMocks.EncodedPresentationRequest))
+            }
+        },
+        resolveDidDocumentRepository = fixedDidDocumentRepository(),
+        jwtServiceRepository = successfulJwtServiceRepository(),
+        presentationRequestByDeepLinkVerifier = object : PresentationRequestByDeepLinkVerifier {
+            override fun verifyPresentationRequest(
+                presentationRequest: VCLPresentationRequest,
+                deepLink: VCLDeepLink,
+                didDocument: VCLDidDocument,
+                completionBlock: (VCLResult<Boolean>) -> Unit,
+            ) {
+                completionBlock(VCLResult.Success(false))
+            }
+        },
+        executor = EmptyExecutor(),
+    ).getPresentationRequest(
+        presentationRequestDescriptor = presentationDescriptor(DeepLinkMocks.PresentationRequestDeepLinkDevNet),
+        verifiedProfile = VCLVerifiedProfile(JSONObject()),
+    ) {
+        it.handleResult(
+            successHandler = { fail("Presentation request failure expected: $it") },
+            errorHandler = { error -> result = error },
+        )
+    }
+    return result ?: error("getPresentationRequest did not invoke errorHandler")
+}
+
+internal fun getCredentialManifestRepositoryNullEndpointError(): VCLError {
+    var result: VCLError? = null
+    CredentialManifestRepositoryImpl(unusedNetworkService()).getCredentialManifest(
+        credentialManifestDescriptor(VCLDeepLink("velocity-network://issue?issuerDid=${EntryPoint.Issuing.requestDid}"))
+    ) {
+        it.handleResult(
+            successHandler = { fail("Credential manifest repository failure expected: $it") },
+            errorHandler = { error -> result = error },
+        )
+    }
+    return result ?: error("getCredentialManifest did not invoke errorHandler")
+}
+
+internal fun getPresentationRequestRepositoryNullEndpointError(): VCLError {
+    var result: VCLError? = null
+    PresentationRequestRepositoryImpl(unusedNetworkService()).getPresentationRequest(
+        presentationDescriptor(VCLDeepLink("velocity-network://inspect?inspectorDid=${EntryPoint.Presentation.requestDid}"))
+    ) {
+        it.handleResult(
+            successHandler = { fail("Presentation request repository failure expected: $it") },
+            errorHandler = { error -> result = error },
+        )
+    }
+    return result ?: error("getPresentationRequest did not invoke errorHandler")
+}
+
+internal fun unusedNetworkService() =
+    object : NetworkService {
+        override fun sendRequest(
+            endpoint: String,
+            body: String?,
+            contentType: String,
+            method: Request.HttpMethod,
+            headers: List<Pair<String, String>>?,
+            useCaches: Boolean,
+            completionBlock: (VCLResult<Response>) -> Unit,
+        ) {
+            fail("Network should not be called for null endpoint")
+        }
+    }
+
+internal fun fixedDidDocumentRepository() =
+    object : ResolveDidDocumentRepository {
+        override fun resolveDidDocument(
+            did: String,
+            completionBlock: (VCLResult<VCLDidDocument>) -> Unit,
+        ) {
+            completionBlock(VCLResult.Success(DidDocumentMocks.DidDocumentMock))
+        }
+    }
+
+internal fun successfulJwtServiceRepository() =
+    object : JwtServiceRepository {
+        override fun decode(
+            encodedJwt: String,
+            completionBlock: (VCLResult<VCLJwt>) -> Unit,
+        ) {
+            completionBlock(VCLResult.Success(VCLJwt(encodedJwt)))
+        }
+
+        override fun verifyJwt(
+            jwt: VCLJwt,
+            publicJwk: VCLPublicJwk,
+            remoteCryptoServicesToken: VCLToken?,
+            completionBlock: (VCLResult<Boolean>) -> Unit,
+        ) {
+            completionBlock(VCLResult.Success(true))
+        }
+
+        override fun generateSignedJwt(
+            jwtDescriptor: VCLJwtDescriptor,
+            nonce: String?,
+            didJwk: VCLDidJwk,
+            remoteCryptoServicesToken: VCLToken?,
+            completionBlock: (VCLResult<VCLJwt>) -> Unit,
+        ) {
+            completionBlock(VCLResult.Success(VCLJwt("")))
+        }
+    }
+
+internal fun initializedVcl(
+    router: BaselineHttpRouter,
+    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
+    errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Taxonomy,
+): VCLImpl {
+    val vcl = VCLImpl(router::connectionFor)
+    var initError: VCLError? = null
+    val latch = CountDownLatch(1)
+    vcl.initialize(
+        context = ApplicationProvider.getApplicationContext(),
+        initializationDescriptor = VCLInitializationDescriptor(
+            cacheSequence = cacheSequence.incrementAndGet(),
+            errorCodeCompatibilityMode = errorCodeCompatibilityMode,
+            cryptoServicesDescriptor = VCLCryptoServicesDescriptor(
+                cryptoServiceType = VCLCryptoServiceType.Injected,
+                injectedCryptoServicesDescriptor = VCLInjectedCryptoServicesDescriptor(
+                    keyService = VCLKeyServiceMock(),
+                    jwtSignService = VCLJwtSignServiceMock(),
+                    jwtVerifyService = FixedJwtVerifyService(jwtVerificationResult),
+                ),
+            ),
+        ),
+        successHandler = {
+            latch.countDown()
+        },
+        errorHandler = {
+            initError = it
+            latch.countDown()
+        },
+    )
+    drainMainThreadUntil(latch)
+    assertNull("VCL initialization failed: ${initError?.toJsonObject()}", initError)
+    return vcl
+}
+
+internal fun awaitCredentialManifestError(
+    vcl: VCLImpl,
+    descriptor: VCLCredentialManifestDescriptor,
+): VCLError {
+    var result: VCLError? = null
+    val latch = CountDownLatch(1)
+    vcl.getCredentialManifest(
+        credentialManifestDescriptor = descriptor,
+        successHandler = { manifest ->
+            fail("Credential manifest failure expected: $manifest")
+        },
+        errorHandler = {
+            result = it
+            latch.countDown()
+        },
+    )
+    drainMainThreadUntil(latch)
+    return result ?: error("getCredentialManifest did not invoke errorHandler")
+}
+
+internal fun awaitCredentialManifest(
+    vcl: VCLImpl,
+    descriptor: VCLCredentialManifestDescriptor,
+): VCLCredentialManifest {
+    var result: VCLCredentialManifest? = null
+    var error: VCLError? = null
+    val latch = CountDownLatch(1)
+    vcl.getCredentialManifest(
+        credentialManifestDescriptor = descriptor,
+        successHandler = {
+            result = it
+            latch.countDown()
+        },
+        errorHandler = {
+            error = it
+            latch.countDown()
+        },
+    )
+    drainMainThreadUntil(latch)
+    error?.let { fail("Credential manifest success expected: $it") }
+    return result ?: error("getCredentialManifest did not invoke successHandler")
+}
+
+internal fun awaitPresentationRequestError(
+    vcl: VCLImpl,
+    descriptor: VCLPresentationRequestDescriptor,
+): VCLError {
+    var result: VCLError? = null
+    val latch = CountDownLatch(1)
+    vcl.getPresentationRequest(
+        presentationRequestDescriptor = descriptor,
+        successHandler = { presentationRequest ->
+            fail("Presentation request failure expected: $presentationRequest")
+        },
+        errorHandler = {
+            result = it
+            latch.countDown()
+        },
+    )
+    drainMainThreadUntil(latch)
+    return result ?: error("getPresentationRequest did not invoke errorHandler")
+}
+
+internal fun drainMainThreadUntil(latch: CountDownLatch) {
+    val deadline = System.currentTimeMillis() + 5_000
+    while (latch.count > 0 && System.currentTimeMillis() < deadline) {
+        shadowOf(android.os.Looper.getMainLooper()).idle()
+        latch.await(20, TimeUnit.MILLISECONDS)
+    }
+    shadowOf(android.os.Looper.getMainLooper()).idle()
+    assertEquals("Timed out waiting for callback", 0, latch.count)
+}
+
+internal fun credentialManifestDescriptor(deepLink: VCLDeepLink) =
+    VCLCredentialManifestDescriptorByDeepLink(
+        deepLink = deepLink,
+        didJwk = DidJwkMocks.DidJwk,
+    )
+
+internal fun credentialManifestDescriptorByService(
+    endpoint: String? = DeepLinkMocks.CredentialManifestRequestDecodedUriStr,
+    did: String = DeepLinkMocks.IssuerDid,
+) =
+    VCLCredentialManifestDescriptorByService(
+        service = VCLService(
+            JSONObject().apply {
+                put(VCLService.KeyId, "${DeepLinkMocks.IssuerDid}#credential-agent-issuer-1")
+                put(VCLService.KeyType, "VelocityCredentialAgentIssuer_v1.0")
+                if (endpoint != null) {
+                    put(VCLService.KeyServiceEndpoint, endpoint)
+                }
+            }
+        ),
+        issuingType = VCLIssuingType.Career,
+        didJwk = DidJwkMocks.DidJwk,
+        did = did,
+    )
+
+internal fun presentationDescriptor(deepLink: VCLDeepLink) =
+    VCLPresentationRequestDescriptor(
+        deepLink = deepLink,
+        didJwk = DidJwkMocks.DidJwk,
+    )
+
+internal class FixedJwtVerifyService(
+    private val result: VCLResult<Boolean>,
+) : VCLJwtVerifyService {
+    override fun verify(
+        jwt: VCLJwt,
+        publicJwk: VCLPublicJwk,
+        remoteCryptoServicesToken: VCLToken?,
+        completionBlock: (VCLResult<Boolean>) -> Unit,
+    ) {
+        completionBlock(result)
+    }
+}
+
+internal data class BaselineHttpRouter(
+    private val verifiedProfilePayload: String = VerifiedProfileMocks.VerifiedProfileIssuerJsonStr1,
+    private val verifiedProfileStatusCode: Int = 200,
+    private val verifiedProfileContentType: String? = Request.ContentTypeApplicationJson,
+    private val requestPayload: String = CredentialManifestMocks.CredentialManifest1,
+    private val requestStatusCode: Int = 200,
+    private val requestContentType: String? = Request.ContentTypeApplicationJson,
+    private val requestFailure: Exception? = null,
+    private val didDocumentPayload: String = DidDocumentMocks.DidDocumentMockStr,
+    private val didDocumentStatusCode: Int = 200,
+    private val didDocumentContentType: String? = Request.ContentTypeApplicationJson,
+) {
+    val requestedEndpoints: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+    fun connectionFor(request: Request): HttpURLConnection {
+        requestedEndpoints.add(request.endpoint)
+        if (isSdkRequestEndpoint(request.endpoint)) {
+            requestFailure?.let { throw it }
+            if (request.endpoint.startsWith("not-a-url")) {
+                throw MalformedURLException("no protocol: ${request.endpoint}")
+            }
+            if (request.endpoint.startsWith("ftp://")) {
+                throw MalformedURLException("unknown protocol: ftp")
+            }
+        }
+        val route = routeFor(request.endpoint)
+        return FakeHttpURLConnection(
+            url = URL(request.endpoint),
+            responseCodeValue = route.statusCode,
+            contentTypeValue = route.contentType,
+            payload = route.payload,
+        )
+    }
+
+    private fun routeFor(endpoint: String): Route =
+        when {
+            endpoint.contains("/reference/countries") ->
+                Route(200, Request.ContentTypeApplicationJson, CountriesMocks.CountriesJson)
+            endpoint.contains("/api/v0.6/credential-types") ->
+                Route(200, Request.ContentTypeApplicationJson, CredentialTypesMocks.CredentialTypesJson)
+            endpoint.contains("/schemas/") ->
+                Route(200, Request.ContentTypeApplicationJson, CredentialTypeSchemaMocks.CredentialTypeSchemaJson)
+            endpoint.contains("/verified-profile") ->
+                Route(verifiedProfileStatusCode, verifiedProfileContentType, verifiedProfilePayload)
+            endpoint.contains("/resolve-did/") ->
+                Route(didDocumentStatusCode, didDocumentContentType, didDocumentPayload)
+            isSdkRequestEndpoint(endpoint) ->
+                Route(requestStatusCode, requestContentType, requestPayload)
+            else ->
+                error("Unhandled HTTP endpoint in baseline test: $endpoint")
+        }
+
+    private fun isSdkRequestEndpoint(endpoint: String): Boolean =
+        endpoint.contains("get-credential-manifest") ||
+            endpoint.contains("get-presentation-request") ||
+            endpoint.startsWith("not-a-url") ||
+            endpoint.startsWith("ftp://")
+}
+
+internal data class Route(
+    val statusCode: Int,
+    val contentType: String?,
+    val payload: String,
+)
+
+internal class FakeHttpURLConnection(
+    url: URL,
+    private val responseCodeValue: Int,
+    private val contentTypeValue: String?,
+    private val payload: String,
+) : HttpURLConnection(url) {
+    override fun connect() = Unit
+
+    override fun disconnect() = Unit
+
+    override fun usingProxy() = false
+
+    override fun getResponseCode(): Int = responseCodeValue
+
+    override fun getContentType(): String? = contentTypeValue
+
+    override fun getErrorStream(): InputStream? =
+        if (responseCodeValue >= HTTP_OK && responseCodeValue <= 299) {
+            null
+        } else {
+            ByteArrayInputStream(payload.toByteArray())
+        }
+
+    override fun getInputStream(): InputStream =
+        ByteArrayInputStream(payload.toByteArray())
+}
+
+private val cacheSequence = AtomicInteger(1000)
+
+internal val EntryPoint.endpointNullMessage: String
+    get() = when (this) {
+        EntryPoint.Issuing -> "credentialManifestDescriptor.endpoint = null"
+        EntryPoint.Presentation -> "presentationRequestDescriptor.endpoint = null"
+    }
+
+internal val EntryPoint.mismatchErrorCode: String
+    get() = legacyMismatchErrorCode

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
@@ -10,25 +10,17 @@ import androidx.test.core.app.ApplicationProvider
 import io.velocitycareerlabs.api.VCLCryptoServiceType
 import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptor
 import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByDeepLink
-import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByService
 import io.velocitycareerlabs.api.entities.VCLDeepLink
-import io.velocitycareerlabs.api.entities.VCLDidDocument
-import io.velocitycareerlabs.api.entities.VCLDidJwk
-import io.velocitycareerlabs.api.entities.VCLIssuingType
 import io.velocitycareerlabs.api.entities.VCLJwt
-import io.velocitycareerlabs.api.entities.VCLJwtDescriptor
 import io.velocitycareerlabs.api.entities.VCLCredentialManifest
 import io.velocitycareerlabs.api.entities.VCLPresentationRequestDescriptor
 import io.velocitycareerlabs.api.entities.VCLPresentationRequest
 import io.velocitycareerlabs.api.entities.VCLPublicJwk
 import io.velocitycareerlabs.api.entities.VCLResult
-import io.velocitycareerlabs.api.entities.VCLService
 import io.velocitycareerlabs.api.entities.VCLToken
-import io.velocitycareerlabs.api.entities.VCLVerifiedProfile
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.api.entities.error.VCLErrorCode
 import io.velocitycareerlabs.api.entities.error.VCLStatusCode
-import io.velocitycareerlabs.api.entities.handleResult
 import io.velocitycareerlabs.api.entities.initialization.VCLCryptoServicesDescriptor
 import io.velocitycareerlabs.api.entities.initialization.VCLInjectedCryptoServicesDescriptor
 import io.velocitycareerlabs.api.entities.initialization.VCLInitializationDescriptor
@@ -36,21 +28,8 @@ import io.velocitycareerlabs.api.entities.initialization.VCLErrorCodeCompatibili
 import io.velocitycareerlabs.api.jwt.VCLJwtVerifyService
 import io.velocitycareerlabs.impl.VCLImpl
 import io.velocitycareerlabs.impl.data.infrastructure.network.Request
-import io.velocitycareerlabs.impl.data.infrastructure.network.Response
-import io.velocitycareerlabs.impl.data.repositories.CredentialManifestRepositoryImpl
-import io.velocitycareerlabs.impl.data.repositories.PresentationRequestRepositoryImpl
-import io.velocitycareerlabs.impl.data.usecases.CredentialManifestUseCaseImpl
-import io.velocitycareerlabs.impl.data.usecases.PresentationRequestUseCaseImpl
-import io.velocitycareerlabs.impl.domain.infrastructure.network.NetworkService
-import io.velocitycareerlabs.impl.domain.repositories.CredentialManifestRepository
-import io.velocitycareerlabs.impl.domain.repositories.JwtServiceRepository
-import io.velocitycareerlabs.impl.domain.repositories.PresentationRequestRepository
-import io.velocitycareerlabs.impl.domain.repositories.ResolveDidDocumentRepository
-import io.velocitycareerlabs.impl.domain.verifiers.CredentialManifestByDeepLinkVerifier
-import io.velocitycareerlabs.impl.domain.verifiers.PresentationRequestByDeepLinkVerifier
 import io.velocitycareerlabs.impl.utils.ProfileServiceTypeVerifier
 import io.velocitycareerlabs.impl.utils.VelocityDeepLinkValidator
-import io.velocitycareerlabs.infrastructure.resources.EmptyExecutor
 import io.velocitycareerlabs.infrastructure.resources.valid.CountriesMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.CredentialManifestMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypeSchemaMocks
@@ -78,7 +57,6 @@ import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
-import java.net.URLEncoder
 import java.net.UnknownHostException
 import java.util.Base64
 import java.util.Collections
@@ -197,9 +175,6 @@ internal fun EntryPoint.expectedDiagnostics(
 
 internal val EntryPoint.lastDid: String get() = "did:example:last"
 
-internal fun simpleRequestUri(): String =
-    URLEncoder.encode("https://example.com/request", "UTF-8")
-
 internal val EntryPoint.defaultRequestJwt: String
     get() = when (this) {
         EntryPoint.Issuing -> CredentialManifestMocks.JwtCredentialManifest1
@@ -289,18 +264,6 @@ internal fun getCredentialManifestError(
     return awaitCredentialManifestError(vcl, credentialManifestDescriptor(deepLink))
 }
 
-internal fun getLegacyCredentialManifestError(
-    deepLink: VCLDeepLink,
-    router: BaselineHttpRouter = BaselineHttpRouter(),
-    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-): VCLError =
-    getCredentialManifestError(
-        deepLink,
-        router,
-        jwtVerificationResult,
-        VCLErrorCodeCompatibilityMode.Legacy,
-    )
-
 internal fun getPresentationRequestError(
     deepLink: VCLDeepLink,
     router: BaselineHttpRouter = BaselineHttpRouter(
@@ -313,173 +276,6 @@ internal fun getPresentationRequestError(
     val vcl = initializedVcl(router, jwtVerificationResult, errorCodeCompatibilityMode)
     return awaitPresentationRequestError(vcl, presentationDescriptor(deepLink))
 }
-
-internal fun getLegacyPresentationRequestError(
-    deepLink: VCLDeepLink,
-    router: BaselineHttpRouter = BaselineHttpRouter(
-        verifiedProfilePayload = VerifiedProfileMocks.VerifiedProfileInspectorJsonStr,
-        requestPayload = PresentationRequestMocks.EncodedPresentationRequestResponse,
-    ),
-    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-): VCLError =
-    getPresentationRequestError(
-        deepLink,
-        router,
-        jwtVerificationResult,
-        VCLErrorCodeCompatibilityMode.Legacy,
-    )
-
-internal fun getCredentialManifestUseCaseVerificationFalseError(): VCLError {
-    var result: VCLError? = null
-    CredentialManifestUseCaseImpl(
-        credentialManifestRepository = object : CredentialManifestRepository {
-            override fun getCredentialManifest(
-                credentialManifestDescriptor: VCLCredentialManifestDescriptor,
-                completionBlock: (VCLResult<String>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(CredentialManifestMocks.JwtCredentialManifest1))
-            }
-        },
-        resolveDidDocumentRepository = fixedDidDocumentRepository(),
-        jwtServiceRepository = successfulJwtServiceRepository(),
-        credentialManifestByDeepLinkVerifier = object : CredentialManifestByDeepLinkVerifier {
-            override fun verifyCredentialManifest(
-                credentialManifest: VCLCredentialManifest,
-                deepLink: VCLDeepLink?,
-                didDocument: VCLDidDocument,
-                completionBlock: (VCLResult<Boolean>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(false))
-            }
-        },
-        executor = EmptyExecutor(),
-    ).getCredentialManifest(
-        credentialManifestDescriptor = credentialManifestDescriptor(DeepLinkMocks.CredentialManifestDeepLinkDevNet),
-        verifiedProfile = VCLVerifiedProfile(JSONObject()),
-    ) {
-        it.handleResult(
-            successHandler = { fail("Credential manifest failure expected: $it") },
-            errorHandler = { error -> result = error },
-        )
-    }
-    return result ?: error("getCredentialManifest did not invoke errorHandler")
-}
-
-internal fun getPresentationRequestUseCaseVerificationFalseError(): VCLError {
-    var result: VCLError? = null
-    PresentationRequestUseCaseImpl(
-        presentationRequestRepository = object : PresentationRequestRepository {
-            override fun getPresentationRequest(
-                presentationRequestDescriptor: VCLPresentationRequestDescriptor,
-                completionBlock: (VCLResult<String>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(PresentationRequestMocks.EncodedPresentationRequest))
-            }
-        },
-        resolveDidDocumentRepository = fixedDidDocumentRepository(),
-        jwtServiceRepository = successfulJwtServiceRepository(),
-        presentationRequestByDeepLinkVerifier = object : PresentationRequestByDeepLinkVerifier {
-            override fun verifyPresentationRequest(
-                presentationRequest: VCLPresentationRequest,
-                deepLink: VCLDeepLink,
-                didDocument: VCLDidDocument,
-                completionBlock: (VCLResult<Boolean>) -> Unit,
-            ) {
-                completionBlock(VCLResult.Success(false))
-            }
-        },
-        executor = EmptyExecutor(),
-    ).getPresentationRequest(
-        presentationRequestDescriptor = presentationDescriptor(DeepLinkMocks.PresentationRequestDeepLinkDevNet),
-        verifiedProfile = VCLVerifiedProfile(JSONObject()),
-    ) {
-        it.handleResult(
-            successHandler = { fail("Presentation request failure expected: $it") },
-            errorHandler = { error -> result = error },
-        )
-    }
-    return result ?: error("getPresentationRequest did not invoke errorHandler")
-}
-
-internal fun getCredentialManifestRepositoryNullEndpointError(): VCLError {
-    var result: VCLError? = null
-    CredentialManifestRepositoryImpl(unusedNetworkService()).getCredentialManifest(
-        credentialManifestDescriptor(VCLDeepLink("velocity-network://issue?issuerDid=${EntryPoint.Issuing.requestDid}"))
-    ) {
-        it.handleResult(
-            successHandler = { fail("Credential manifest repository failure expected: $it") },
-            errorHandler = { error -> result = error },
-        )
-    }
-    return result ?: error("getCredentialManifest did not invoke errorHandler")
-}
-
-internal fun getPresentationRequestRepositoryNullEndpointError(): VCLError {
-    var result: VCLError? = null
-    PresentationRequestRepositoryImpl(unusedNetworkService()).getPresentationRequest(
-        presentationDescriptor(VCLDeepLink("velocity-network://inspect?inspectorDid=${EntryPoint.Presentation.requestDid}"))
-    ) {
-        it.handleResult(
-            successHandler = { fail("Presentation request repository failure expected: $it") },
-            errorHandler = { error -> result = error },
-        )
-    }
-    return result ?: error("getPresentationRequest did not invoke errorHandler")
-}
-
-internal fun unusedNetworkService() =
-    object : NetworkService {
-        override fun sendRequest(
-            endpoint: String,
-            body: String?,
-            contentType: String,
-            method: Request.HttpMethod,
-            headers: List<Pair<String, String>>?,
-            useCaches: Boolean,
-            completionBlock: (VCLResult<Response>) -> Unit,
-        ) {
-            fail("Network should not be called for null endpoint")
-        }
-    }
-
-internal fun fixedDidDocumentRepository() =
-    object : ResolveDidDocumentRepository {
-        override fun resolveDidDocument(
-            did: String,
-            completionBlock: (VCLResult<VCLDidDocument>) -> Unit,
-        ) {
-            completionBlock(VCLResult.Success(DidDocumentMocks.DidDocumentMock))
-        }
-    }
-
-internal fun successfulJwtServiceRepository() =
-    object : JwtServiceRepository {
-        override fun decode(
-            encodedJwt: String,
-            completionBlock: (VCLResult<VCLJwt>) -> Unit,
-        ) {
-            completionBlock(VCLResult.Success(VCLJwt(encodedJwt)))
-        }
-
-        override fun verifyJwt(
-            jwt: VCLJwt,
-            publicJwk: VCLPublicJwk,
-            remoteCryptoServicesToken: VCLToken?,
-            completionBlock: (VCLResult<Boolean>) -> Unit,
-        ) {
-            completionBlock(VCLResult.Success(true))
-        }
-
-        override fun generateSignedJwt(
-            jwtDescriptor: VCLJwtDescriptor,
-            nonce: String?,
-            didJwk: VCLDidJwk,
-            remoteCryptoServicesToken: VCLToken?,
-            completionBlock: (VCLResult<VCLJwt>) -> Unit,
-        ) {
-            completionBlock(VCLResult.Success(VCLJwt("")))
-        }
-    }
 
 internal fun initializedVcl(
     router: BaselineHttpRouter,
@@ -536,29 +332,6 @@ internal fun awaitCredentialManifestError(
     return result ?: error("getCredentialManifest did not invoke errorHandler")
 }
 
-internal fun awaitCredentialManifest(
-    vcl: VCLImpl,
-    descriptor: VCLCredentialManifestDescriptor,
-): VCLCredentialManifest {
-    var result: VCLCredentialManifest? = null
-    var error: VCLError? = null
-    val latch = CountDownLatch(1)
-    vcl.getCredentialManifest(
-        credentialManifestDescriptor = descriptor,
-        successHandler = {
-            result = it
-            latch.countDown()
-        },
-        errorHandler = {
-            error = it
-            latch.countDown()
-        },
-    )
-    drainMainThreadUntil(latch)
-    error?.let { fail("Credential manifest success expected: $it") }
-    return result ?: error("getCredentialManifest did not invoke successHandler")
-}
-
 internal fun awaitPresentationRequestError(
     vcl: VCLImpl,
     descriptor: VCLPresentationRequestDescriptor,
@@ -593,25 +366,6 @@ internal fun credentialManifestDescriptor(deepLink: VCLDeepLink) =
     VCLCredentialManifestDescriptorByDeepLink(
         deepLink = deepLink,
         didJwk = DidJwkMocks.DidJwk,
-    )
-
-internal fun credentialManifestDescriptorByService(
-    endpoint: String? = DeepLinkMocks.CredentialManifestRequestDecodedUriStr,
-    did: String = DeepLinkMocks.IssuerDid,
-) =
-    VCLCredentialManifestDescriptorByService(
-        service = VCLService(
-            JSONObject().apply {
-                put(VCLService.KeyId, "${DeepLinkMocks.IssuerDid}#credential-agent-issuer-1")
-                put(VCLService.KeyType, "VelocityCredentialAgentIssuer_v1.0")
-                if (endpoint != null) {
-                    put(VCLService.KeyServiceEndpoint, endpoint)
-                }
-            }
-        ),
-        issuingType = VCLIssuingType.Career,
-        didJwk = DidJwkMocks.DidJwk,
-        did = did,
     )
 
 internal fun presentationDescriptor(deepLink: VCLDeepLink) =

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider
 import io.velocitycareerlabs.api.VCLCryptoServiceType
 import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptor
 import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByDeepLink
+import io.velocitycareerlabs.api.entities.VCLCredentialManifestDescriptorByService
 import io.velocitycareerlabs.api.entities.VCLDeepLink
 import io.velocitycareerlabs.api.entities.VCLJwt
 import io.velocitycareerlabs.api.entities.VCLCredentialManifest
@@ -17,6 +18,7 @@ import io.velocitycareerlabs.api.entities.VCLPresentationRequestDescriptor
 import io.velocitycareerlabs.api.entities.VCLPresentationRequest
 import io.velocitycareerlabs.api.entities.VCLPublicJwk
 import io.velocitycareerlabs.api.entities.VCLResult
+import io.velocitycareerlabs.api.entities.VCLService
 import io.velocitycareerlabs.api.entities.VCLToken
 import io.velocitycareerlabs.api.entities.error.VCLError
 import io.velocitycareerlabs.api.entities.error.VCLErrorCode
@@ -31,6 +33,7 @@ import io.velocitycareerlabs.impl.data.infrastructure.network.Request
 import io.velocitycareerlabs.impl.utils.ProfileServiceTypeVerifier
 import io.velocitycareerlabs.impl.utils.VelocityDeepLinkValidator
 import io.velocitycareerlabs.infrastructure.resources.valid.CountriesMocks
+import io.velocitycareerlabs.infrastructure.resources.valid.CredentialManifestDescriptorMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.CredentialManifestMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypeSchemaMocks
 import io.velocitycareerlabs.infrastructure.resources.valid.CredentialTypesMocks
@@ -332,6 +335,29 @@ internal fun awaitCredentialManifestError(
     return result ?: error("getCredentialManifest did not invoke errorHandler")
 }
 
+internal fun awaitCredentialManifest(
+    vcl: VCLImpl,
+    descriptor: VCLCredentialManifestDescriptor,
+): VCLCredentialManifest {
+    var result: VCLCredentialManifest? = null
+    var error: VCLError? = null
+    val latch = CountDownLatch(1)
+    vcl.getCredentialManifest(
+        credentialManifestDescriptor = descriptor,
+        successHandler = { manifest ->
+            result = manifest
+            latch.countDown()
+        },
+        errorHandler = {
+            error = it
+            latch.countDown()
+        },
+    )
+    drainMainThreadUntil(latch)
+    assertNull("Credential manifest success expected: ${error?.toJsonObject()}", error)
+    return result ?: error("getCredentialManifest did not invoke successHandler")
+}
+
 internal fun awaitPresentationRequestError(
     vcl: VCLImpl,
     descriptor: VCLPresentationRequestDescriptor,
@@ -366,6 +392,21 @@ internal fun credentialManifestDescriptor(deepLink: VCLDeepLink) =
     VCLCredentialManifestDescriptorByDeepLink(
         deepLink = deepLink,
         didJwk = DidJwkMocks.DidJwk,
+    )
+
+internal fun credentialManifestDescriptorByService(
+    endpoint: String = CredentialManifestDescriptorMocks.IssuingServiceEndPoint,
+    did: String = DeepLinkMocks.IssuerDid,
+) =
+    VCLCredentialManifestDescriptorByService(
+        service = VCLService(
+            JSONObject(CredentialManifestDescriptorMocks.IssuingServiceJsonStr).put(
+                VCLService.KeyServiceEndpoint,
+                endpoint,
+            )
+        ),
+        didJwk = DidJwkMocks.DidJwk,
+        did = did,
     )
 
 internal fun presentationDescriptor(deepLink: VCLDeepLink) =

--- a/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/integration/ErrorTaxonomyTestHarness.kt
@@ -301,28 +301,6 @@ internal fun getLegacyCredentialManifestError(
         VCLErrorCodeCompatibilityMode.Legacy,
     )
 
-internal fun getCredentialManifestDescriptorError(
-    descriptor: VCLCredentialManifestDescriptor,
-    router: BaselineHttpRouter = BaselineHttpRouter(),
-    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-    errorCodeCompatibilityMode: VCLErrorCodeCompatibilityMode = VCLErrorCodeCompatibilityMode.Taxonomy,
-): VCLError {
-    val vcl = initializedVcl(router, jwtVerificationResult, errorCodeCompatibilityMode)
-    return awaitCredentialManifestError(vcl, descriptor)
-}
-
-internal fun getLegacyCredentialManifestDescriptorError(
-    descriptor: VCLCredentialManifestDescriptor,
-    router: BaselineHttpRouter = BaselineHttpRouter(),
-    jwtVerificationResult: VCLResult<Boolean> = VCLResult.Success(true),
-): VCLError =
-    getCredentialManifestDescriptorError(
-        descriptor,
-        router,
-        jwtVerificationResult,
-        VCLErrorCodeCompatibilityMode.Legacy,
-    )
-
 internal fun getPresentationRequestError(
     deepLink: VCLDeepLink,
     router: BaselineHttpRouter = BaselineHttpRouter(

--- a/VCL/src/test/java/io/velocitycareerlabs/usecases/CredentialManifestUseCaseTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/usecases/CredentialManifestUseCaseTest.kt
@@ -130,10 +130,11 @@ internal class CredentialManifestUseCaseTest {
         ) {
             it.handleResult(
                 successHandler = {
-                    assert(false) { "${VCLErrorCode.ClientRequestRejected.value} error code is expected" }
+                    assert(false) { "${VCLErrorCode.IssuerRequestInvalid.value} error code is expected" }
                 },
                 errorHandler = { error ->
-                    assert(error.errorCode == VCLErrorCode.ClientRequestRejected.value)
+                    assert(error.errorCode == VCLErrorCode.IssuerRequestInvalid.value)
+                    assert(error.requestUri == DeepLinkMocks.CredentialManifestDeepLinkDevNet.requestUri)
                 }
             )
         }

--- a/VCL/src/test/java/io/velocitycareerlabs/usecases/PresentationRequestUseCaseTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/usecases/PresentationRequestUseCaseTest.kt
@@ -114,10 +114,11 @@ internal class PresentationRequestUseCaseTest {
         ) {
             it.handleResult(
                 successHandler = {
-                    assert(false) { "${VCLErrorCode.ClientRequestRejected.value} error code is expected" }
+                    assert(false) { "${VCLErrorCode.VerifierRequestInvalid.value} error code is expected" }
                 },
                 errorHandler = { error ->
-                    assert(error.errorCode == VCLErrorCode.ClientRequestRejected.value)
+                    assert(error.errorCode == VCLErrorCode.VerifierRequestInvalid.value)
+                    assert(error.requestUri == DeepLinkMocks.PresentationRequestDeepLinkDevNet.requestUri)
                 }
             )
         }

--- a/VCL/src/test/java/io/velocitycareerlabs/verifiers/CredentialManifestByDeepLinkVerifierTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/verifiers/CredentialManifestByDeepLinkVerifierTest.kt
@@ -41,9 +41,7 @@ class CredentialManifestByDeepLinkVerifierTest {
             DeepLinkMocks.CredentialManifestDeepLinkDevNet,
             DidDocumentMocks.DidDocumentMock
         ) {
-            it.handleResult({ isVerified ->
-                assert(isVerified)
-            }, { error ->
+            it.handleResult({}, { error ->
                 assert(false) { "${error.toJsonObject()}" }
             })
         }

--- a/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
@@ -12,7 +12,6 @@ import io.velocitycareerlabs.infrastructure.resources.valid.PresentationRequestM
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import java.net.URLEncoder
@@ -97,24 +96,6 @@ class PresentationRequestByDeepLinkVerifierTest {
                 fail("${VCLErrorCode.VerifierRequestInvalid.value} error code is expected")
             }, { error ->
                 assertEquals(VCLErrorCode.VerifierRequestInvalid.value, error.errorCode)
-            })
-        }
-    }
-
-    @Test
-    fun testVerifyPresentationRequestErrorWhenDeepLinkDidMissing() {
-        subject = PresentationRequestByDeepLinkVerifierImpl()
-
-        subject.verifyPresentationRequest(
-            presentationRequest,
-            VCLDeepLink(value = "velocity-network://inspect"),
-            DidDocumentMocks.DidDocumentMock
-        ) {
-            it.handleResult({
-                fail("${VCLErrorCode.VerifierRequestInvalid.value} error code is expected")
-            }, { error ->
-                assertEquals(VCLErrorCode.VerifierRequestInvalid.value, error.errorCode)
-                assertTrue(error.message?.contains("DID not found in deep link") == true)
             })
         }
     }

--- a/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
+++ b/VCL/src/test/java/io/velocitycareerlabs/verifiers/PresentationRequestByDeepLinkVerifierTest.kt
@@ -32,9 +32,7 @@ class PresentationRequestByDeepLinkVerifierTest {
             DeepLinkMocks.PresentationRequestDeepLinkDevNet,
             DidDocumentMocks.DidDocumentMock
         ) {
-            it.handleResult({ isVerified ->
-                assertTrue(isVerified)
-            }, { error ->
+            it.handleResult({}, { error ->
                 fail("${error.toJsonObject()}")
             })
         }
@@ -50,9 +48,7 @@ class PresentationRequestByDeepLinkVerifierTest {
             deepLinkWithDidDocumentId,
             DidDocumentMocks.DidDocumentMock
         ) {
-            it.handleResult({ isVerified ->
-                assertTrue(isVerified)
-            }, { error ->
+            it.handleResult({}, { error ->
                 fail("${error.toJsonObject()}")
             })
         }
@@ -82,9 +78,7 @@ class PresentationRequestByDeepLinkVerifierTest {
             deepLinkWithDidDocumentAlias,
             didDocumentWithPresentationRequestIss
         ) {
-            it.handleResult({ isVerified ->
-                assertTrue(isVerified)
-            }, { error ->
+            it.handleResult({}, { error ->
                 fail("${error.toJsonObject()}")
             })
         }


### PR DESCRIPTION
## Summary

- Move the error taxonomy contract and legacy baseline specs into the `integration` test package.
- Extract shared entry-point setup, fake HTTP routing, JWT helpers, VCL initialization, and assertion helpers into a reusable taxonomy test harness.
- Remove direct repository/usecase/descriptor coverage from the taxonomy integration suites; contract and baseline assertions now go through SDK entry points.
- Add direct `VCLCredentialManifestDescriptorByService` entry-point coverage for invalid endpoint, missing endpoint, missing DID, and successful by-service issuing without deep-link verification.
- Flatten the credential-manifest and presentation-request use-case callback flow with a small internal `VCLAsyncResult` chain and shared public-request phases.
- Port the Android-safe production changes from LFDT-Verii/core#692: request JWT parsing now goes through `JwtServiceRepository.decode` in the use cases, so malformed issuing and presentation request JWTs are classified as request validation errors.
- Reclassify failed request JWT extraction, malformed request endpoint payloads, and missing or empty request JWT fields as request validation errors instead of client request fetch errors.
- Classify request JWTs missing `iss` as `issuer_request_invalid` / `verifier_request_invalid` from the public entry points.
- Add `registration_check_inconclusive` for registration/profile checks that fail without proving the issuer/verifier is unregistered; keep verified-profile `404` mapped to `issuer_not_registered` / `verifier_not_registered`.
- Preserve `requestUri` on `issuer_request_invalid` / `verifier_request_invalid` errors when the endpoint or deep-link request URI is available.
- Remove repository-level null endpoint taxonomy handling from credential-manifest and presentation-request repositories.
- Make `JwtServiceRepositoryImpl.decode` fail malformed JWTs whose parsed `SignedJWT` is null.
- Simplify credential-manifest and presentation-request deep-link verifiers to return success-or-error instead of a redundant Boolean result, and rely on entry-point validation for deep-link DID presence.
- Keep taxonomy contract coverage in taxonomy mode while making the legacy baseline suite opt into legacy compatibility mode explicitly.

## Validation

- `./gradlew VCL:testDebugUnitTest --tests 'io.velocitycareerlabs.integration.*' --tests io.velocitycareerlabs.verifiers.CredentialManifestByDeepLinkVerifierTest --tests io.velocitycareerlabs.verifiers.PresentationRequestByDeepLinkVerifierTest --tests io.velocitycareerlabs.usecases.CredentialManifestUseCaseTest --tests io.velocitycareerlabs.usecases.PresentationRequestUseCaseTest`
- `./gradlew VCL:testDebugUnitTest --tests 'io.velocitycareerlabs.integration.*'`
- `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.verifiers.CredentialManifestByDeepLinkVerifierTest --tests io.velocitycareerlabs.verifiers.PresentationRequestByDeepLinkVerifierTest --tests io.velocitycareerlabs.usecases.CredentialManifestUseCaseTest --tests io.velocitycareerlabs.usecases.PresentationRequestUseCaseTest`
- `./gradlew VCL:testDebugUnitTest --tests 'io.velocitycareerlabs.integration.*' --tests io.velocitycareerlabs.usecases.PresentationRequestUseCaseTest --tests io.velocitycareerlabs.usecases.CredentialManifestUseCaseTest`
- `./gradlew VCL:testDebugUnitTest --tests 'io.velocitycareerlabs.integration.*' --tests io.velocitycareerlabs.usecases.PresentationRequestUseCaseTest --tests io.velocitycareerlabs.usecases.CredentialManifestUseCaseTest --tests io.velocitycareerlabs.usecases.JwtServiceUseCaseTest`
- `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.entities.VCLJwtTest --tests io.velocitycareerlabs.entities.VCLSubmissionResultTest --tests io.velocitycareerlabs.entities.VCLSubmissionTest --tests io.velocitycareerlabs.usecases.JwtServiceUseCaseTest`
- `./gradlew VCL:testDebugUnitTest --tests io.velocitycareerlabs.usecases.FinalizeOffersUseCaseTest.testFailedCredentials`

## Notes

The full `./gradlew VCL:testDebugUnitTest` run is currently order-sensitive outside this refactor: one run failed `FinalizeOffersUseCaseTest.testFailedCredentials` at line 171, and another failed `testPassedCredentials` at line 224. The targeted finalize-offers test passes by itself, and the taxonomy integration suite passes directly.
