### PR TITLE
[codex] Fix SDK RC publishing version

### DIFF
--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -32,13 +32,16 @@ jobs:
       - name: 📝 Get version from build.gradle
         run: |
           VERSION=$(grep 'publishVersion *= *".*"' VCL/build.gradle | sed -n 's/.*publishVersion *= *"\([^"]*\)".*/\1/p')
+          MAVEN_VERSION="${VERSION}${{ github.event.inputs.environment == 'rc' && '-rc' || '' }}"
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "MAVEN_VERSION=$MAVEN_VERSION" >> "$GITHUB_ENV"
           echo "Found version: $VERSION"
+          echo "Maven version: $MAVEN_VERSION"
 
       - name: 🔧 Set publication name and POM file name
         run: |
           echo "PUBLICATION_NAME=${{ github.event.inputs.environment == 'rc' && 'rc' || 'release' }}" >> "$GITHUB_ENV"
-          echo "POM_FILE_NAME=vcl-${{ github.event.inputs.environment == 'rc' && 'rc-' || '' }}${RELEASE_VERSION}.pom" >> "$GITHUB_ENV"
+          echo "POM_FILE_NAME=vcl-${MAVEN_VERSION}.pom" >> "$GITHUB_ENV"
 
       - name: 🧪 Build AAR + Sources + Javadoc
         run: |
@@ -55,12 +58,13 @@ jobs:
 
       - name: 📦 Stage Artifacts
         run: |
-          ./gradlew :VCL:stageArtifacts
+          ./gradlew :VCL:stageArtifacts \
+            -Pprerelease=${{ github.event.inputs.environment == 'rc' }}
 
       - name: 🧪 Generate POM File
         run: |
           ./gradlew :VCL:generatePomFileFor${{ env.PUBLICATION_NAME }}Publication
-          cp VCL/build/publications/${{ env.PUBLICATION_NAME }}/pom-default.xml "VCL/target/staging-deploy/io/velocitycareerlabs/vcl/${RELEASE_VERSION}/${{ env.POM_FILE_NAME }}"
+          cp VCL/build/publications/${{ env.PUBLICATION_NAME }}/pom-default.xml "VCL/target/staging-deploy/io/velocitycareerlabs/vcl/${MAVEN_VERSION}/${{ env.POM_FILE_NAME }}"
 
       - name: 📂 List staged artifacts
         run: |
@@ -81,11 +85,10 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
           JRELEASER_MAVENCENTRAL_STAGE: ${{ secrets.MAVEN_CENTRAL_STAGING_PROFILE_ID }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_PROJECT_VERSION: ${{ env.RELEASE_VERSION }}
+          JRELEASER_PROJECT_VERSION: ${{ env.MAVEN_VERSION }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_PASSWORD }}
           JRELEASER_TAG_NAME: ${{ github.event.inputs.environment == 'rc' && 'rc-' || '' }}${{ env.RELEASE_VERSION }}
           JRELEASER_RELEASE_NAME: ${{ github.event.inputs.environment == 'rc' && 'Release Candidate ' || '' }}${{ env.RELEASE_VERSION }}
           JRELEASER_PRERELEASE_PATTERN: ${{ github.event.inputs.environment == 'rc' && env.RELEASE_VERSION || 'OFF' }}
-          

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.velocitycareerlabs:vcl:2.9.2' // or latest version
+    implementation 'io.velocitycareerlabs:vcl:2.10.0' // or latest version
     implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
     implementation "androidx.security:security-crypto:1.1.0-alpha07"
 }

--- a/VCL/build.gradle
+++ b/VCL/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    publishCode = 175
+    publishCode = 176
     publishVersion = "2.10.0"
     publishArtifactId = "vcl"
     publishGroupId = "io.velocitycareerlabs"

--- a/VCL/build.gradle
+++ b/VCL/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 ext {
     publishCode = 175
-    publishVersion = "2.9.2"
+    publishVersion = "2.10.0"
     publishArtifactId = "vcl"
     publishGroupId = "io.velocitycareerlabs"
 }
@@ -142,12 +142,21 @@ tasks.register("verifyExpectedArtifactsExist") {
 }
 
 tasks.register("stageArtifacts", Copy) {
-    def mavenPath = "${publishGroupId.replace('.', '/')}/${publishArtifactId}/${publishVersion}/"
+    def isPrerelease = providers.gradleProperty("prerelease")
+        .map { it.toBoolean() }
+        .getOrElse(false)
+    def mavenVersion = isPrerelease ? "${publishVersion}-rc" : publishVersion
+    def mavenPath = "${publishGroupId.replace('.', '/')}/${publishArtifactId}/${mavenVersion}/"
     from("${layout.buildDirectory.get()}/outputs/aar") {
         include("**/*.aar")
     }
     from("${layout.buildDirectory.get()}/libs") {
         include("**/*.jar")
+        if (isPrerelease) {
+            rename { fileName ->
+                fileName.replace("${publishArtifactId}-${publishVersion}-", "${publishArtifactId}-${mavenVersion}-")
+            }
+        }
     }
     into("target/staging-deploy/${mavenPath}")
 }


### PR DESCRIPTION
## Summary

Fixes the SDK RC publishing flow so release candidates publish to the prerelease Maven coordinate instead of colliding with the final release coordinate.

## Root cause

The RC workflow generated an RC POM, but `stageArtifacts` still copied artifacts into `io/velocitycareerlabs/vcl/<base-version>/`. For the failed `2.9.2` run, that meant RC artifacts were staged under `vcl/2.9.2`, where Maven Central had already received release artifacts.

## Changes

- Bump the SDK base version from `2.9.2` to `2.10.0`.
- Bump `publishCode` from `175` to `176` to match the new SDK release.
- Update the README install snippet to `io.velocitycareerlabs:vcl:2.10.0`.
- Add a workflow-level `MAVEN_VERSION`, using `2.10.0-rc` for RC and `2.10.0` for prod.
- Stage RC artifacts under `vcl/<version>-rc`.
- Rename RC source and javadoc jars so all staged files match the RC Maven version.
- Pass the resolved Maven version into JReleaser.

## Validation

- `rg -n "2\.9\.2|2\.10\.0|publishVersion|publishCode|implementation 'io\.velocitycareerlabs:vcl" . -g '!**/build/**' -g '!**/.gradle/**' -g '!**/target/**'`
- `git diff --check -- README.md .github/workflows/android-sdk.yml VCL/build.gradle`
- `./gradlew clean :VCL:assembleAllRc -PprojectVersion=2.10.0 -Pprerelease=true --stacktrace`
- `./gradlew :VCL:stageArtifacts -Pprerelease=true`
- `./gradlew :VCL:generatePomFileForrcPublication`
- Confirmed staged RC files are under `io/velocitycareerlabs/vcl/2.10.0-rc/` and the generated POM has `<version>2.10.0-rc</version>`.
