### PR TITLE
Support numbered SDK RC versions

### DIFF
--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -11,6 +11,10 @@ on:
           - dev
           - rc
           - prod
+      rc_number:
+        description: 'Release candidate number. Required when environment is rc.'
+        required: false
+        type: string
 
 jobs:
   release-android-sdk:
@@ -19,6 +23,8 @@ jobs:
     steps:
       - name: 🧾 Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: ☕ Set up Java 17
         uses: actions/setup-java@v4
@@ -29,42 +35,130 @@ jobs:
       - name: 🛠️ Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: 📝 Get version from build.gradle
+      - name: 📝 Validate inputs and compute versions
+        id: versions
         run: |
-          VERSION=$(grep 'publishVersion *= *".*"' VCL/build.gradle | sed -n 's/.*publishVersion *= *"\([^"]*\)".*/\1/p')
-          MAVEN_VERSION="${VERSION}${{ github.event.inputs.environment == 'rc' && '-rc' || '' }}"
-          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
-          echo "MAVEN_VERSION=$MAVEN_VERSION" >> "$GITHUB_ENV"
-          echo "Found version: $VERSION"
-          echo "Maven version: $MAVEN_VERSION"
+          set -euo pipefail
 
-      - name: 🔧 Set publication name and POM file name
+          ENVIRONMENT="${{ github.event.inputs.environment }}"
+          RC_NUMBER="${{ github.event.inputs.rc_number }}"
+          BASE_MAVEN_VERSION=$(grep 'publishVersion *= *".*"' VCL/build.gradle | sed -n 's/.*publishVersion *= *"\([^"]*\)".*/\1/p')
+
+          if [[ ! "$BASE_MAVEN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::publishVersion must be a semver base version like 2.10.0. Found: ${BASE_MAVEN_VERSION}"
+            exit 1
+          fi
+
+          IS_RC=false
+          BUILD_TYPE=Release
+          PUBLICATION_NAME=release
+          PUBLICATION_TASK_SUFFIX=Release
+          MAVEN_VERSION="$BASE_MAVEN_VERSION"
+
+          if [[ "$ENVIRONMENT" == "rc" ]]; then
+            if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+              echo "::error::rc_number is required for rc releases and must be a positive integer."
+              exit 1
+            fi
+
+            IS_RC=true
+            BUILD_TYPE=Rc
+            PUBLICATION_NAME=rc
+            PUBLICATION_TASK_SUFFIX=Rc
+            MAVEN_VERSION="${BASE_MAVEN_VERSION}-rc.${RC_NUMBER}"
+          elif [[ -n "$RC_NUMBER" ]]; then
+            echo "::warning::rc_number is ignored when environment is ${ENVIRONMENT}."
+          fi
+
+          RELEASE_VERSION="v${MAVEN_VERSION}"
+
+          {
+            echo "BASE_MAVEN_VERSION=${BASE_MAVEN_VERSION}"
+            echo "MAVEN_VERSION=${MAVEN_VERSION}"
+            echo "RELEASE_VERSION=${RELEASE_VERSION}"
+            echo "IS_RC=${IS_RC}"
+            echo "BUILD_TYPE=${BUILD_TYPE}"
+            echo "PUBLICATION_NAME=${PUBLICATION_NAME}"
+            echo "PUBLICATION_TASK_SUFFIX=${PUBLICATION_TASK_SUFFIX}"
+            echo "POM_FILE_NAME=vcl-${MAVEN_VERSION}.pom"
+          } >> "$GITHUB_ENV"
+
+          {
+            echo "base_maven_version=${BASE_MAVEN_VERSION}"
+            echo "maven_version=${MAVEN_VERSION}"
+            echo "release_version=${RELEASE_VERSION}"
+            echo "is_rc=${IS_RC}"
+            echo "build_type=${BUILD_TYPE}"
+            echo "publication_name=${PUBLICATION_NAME}"
+            echo "publication_task_suffix=${PUBLICATION_TASK_SUFFIX}"
+            echo "pom_file_name=vcl-${MAVEN_VERSION}.pom"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Base Maven version: ${BASE_MAVEN_VERSION}"
+          echo "Maven version: ${MAVEN_VERSION}"
+          echo "GitHub release version: ${RELEASE_VERSION}"
+
+      - name: 🔎 Check release collisions
+        if: github.event.inputs.environment != 'dev'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "PUBLICATION_NAME=${{ github.event.inputs.environment == 'rc' && 'rc' || 'release' }}" >> "$GITHUB_ENV"
-          echo "POM_FILE_NAME=vcl-${MAVEN_VERSION}.pom" >> "$GITHUB_ENV"
+          set -euo pipefail
+
+          MAVEN_POM_URL="https://repo.maven.apache.org/maven2/io/velocitycareerlabs/vcl/${MAVEN_VERSION}/vcl-${MAVEN_VERSION}.pom"
+          if curl --silent --fail --head "$MAVEN_POM_URL" >/dev/null; then
+            echo "::error::Maven Central artifact already exists: ${MAVEN_POM_URL}"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "::error::Git tag already exists: ${RELEASE_VERSION}"
+            exit 1
+          fi
+
+          RELEASE_RESPONSE=$(mktemp)
+          RELEASE_STATUS=$(curl --silent --output "$RELEASE_RESPONSE" --write-out "%{http_code}" \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_VERSION}")
+
+          if [[ "$RELEASE_STATUS" == "200" ]]; then
+            echo "::error::GitHub release already exists for ${RELEASE_VERSION}."
+            exit 1
+          elif [[ "$RELEASE_STATUS" != "404" ]]; then
+            echo "::error::Unable to check GitHub release collision for ${RELEASE_VERSION}. HTTP ${RELEASE_STATUS}."
+            cat "$RELEASE_RESPONSE"
+            exit 1
+          fi
 
       - name: 🧪 Build AAR + Sources + Javadoc
         run: |
           ./gradlew clean \
-            :VCL:assembleAll${{ github.event.inputs.environment == 'rc' && 'Rc' || 'Release' }} \
-            -PprojectVersion="${RELEASE_VERSION}" \
-            -Pprerelease=${{ github.event.inputs.environment == 'rc' }} \
+            ":VCL:assembleAll${BUILD_TYPE}" \
+            "-PprojectVersion=${MAVEN_VERSION}" \
+            "-Pprerelease=${IS_RC}" \
             --stacktrace
 
       - name: ✅ Verify expected artifacts exist
         run: |
           ./gradlew \
-            :VCL:verifyExpectedArtifactsExist
+            :VCL:verifyExpectedArtifactsExist \
+            "-PprojectVersion=${MAVEN_VERSION}" \
+            "-Pprerelease=${IS_RC}"
 
       - name: 📦 Stage Artifacts
         run: |
           ./gradlew :VCL:stageArtifacts \
-            -Pprerelease=${{ github.event.inputs.environment == 'rc' }}
+            "-PprojectVersion=${MAVEN_VERSION}" \
+            "-Pprerelease=${IS_RC}"
 
       - name: 🧪 Generate POM File
         run: |
-          ./gradlew :VCL:generatePomFileFor${{ env.PUBLICATION_NAME }}Publication
-          cp VCL/build/publications/${{ env.PUBLICATION_NAME }}/pom-default.xml "VCL/target/staging-deploy/io/velocitycareerlabs/vcl/${MAVEN_VERSION}/${{ env.POM_FILE_NAME }}"
+          ./gradlew ":VCL:generatePomFileFor${PUBLICATION_TASK_SUFFIX}Publication" \
+            "-PprojectVersion=${MAVEN_VERSION}" \
+            "-Pprerelease=${IS_RC}"
+          cp "VCL/build/publications/${PUBLICATION_NAME}/pom-default.xml" "VCL/target/staging-deploy/io/velocitycareerlabs/vcl/${MAVEN_VERSION}/${POM_FILE_NAME}"
 
       - name: 📂 List staged artifacts
         run: |
@@ -80,15 +174,15 @@ jobs:
             --config-file=jreleaser.template.yml
             --debug
         env:
-          JRELEASER_PROJECT_JAVA_ARTIFACT_ID: ${{ github.event.inputs.environment == 'rc' && 'vcl-rc' || 'vcl' }}
+          JRELEASER_PROJECT_JAVA_ARTIFACT_ID: vcl
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
           JRELEASER_MAVENCENTRAL_STAGE: ${{ secrets.MAVEN_CENTRAL_STAGING_PROFILE_ID }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_PROJECT_VERSION: ${{ env.MAVEN_VERSION }}
+          JRELEASER_PROJECT_VERSION: ${{ steps.versions.outputs.maven_version }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_PASSWORD }}
-          JRELEASER_TAG_NAME: ${{ github.event.inputs.environment == 'rc' && 'rc-' || '' }}${{ env.RELEASE_VERSION }}
-          JRELEASER_RELEASE_NAME: ${{ github.event.inputs.environment == 'rc' && 'Release Candidate ' || '' }}${{ env.RELEASE_VERSION }}
-          JRELEASER_PRERELEASE_PATTERN: ${{ github.event.inputs.environment == 'rc' && env.RELEASE_VERSION || 'OFF' }}
+          JRELEASER_TAG_NAME: ${{ steps.versions.outputs.release_version }}
+          JRELEASER_RELEASE_NAME: ${{ steps.versions.outputs.release_version }}
+          JRELEASER_PRERELEASE_PATTERN: ${{ github.event.inputs.environment == 'rc' && steps.versions.outputs.maven_version || 'OFF' }}

--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: ☕ Set up Java 17
         uses: actions/setup-java@v4
@@ -37,11 +38,14 @@ jobs:
 
       - name: 📝 Validate inputs and compute versions
         id: versions
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          INPUT_RC_NUMBER: ${{ github.event.inputs.rc_number }}
         run: |
           set -euo pipefail
 
-          ENVIRONMENT="${{ github.event.inputs.environment }}"
-          RC_NUMBER="${{ github.event.inputs.rc_number }}"
+          ENVIRONMENT="${INPUT_ENVIRONMENT}"
+          RC_NUMBER="${INPUT_RC_NUMBER}"
           BASE_MAVEN_VERSION=$(grep 'publishVersion *= *".*"' VCL/build.gradle | sed -n 's/.*publishVersion *= *"\([^"]*\)".*/\1/p')
 
           if [[ ! "$BASE_MAVEN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -110,8 +114,16 @@ jobs:
           set -euo pipefail
 
           MAVEN_POM_URL="https://repo.maven.apache.org/maven2/io/velocitycareerlabs/vcl/${MAVEN_VERSION}/vcl-${MAVEN_VERSION}.pom"
-          if curl --silent --fail --head "$MAVEN_POM_URL" >/dev/null; then
+          if ! MAVEN_STATUS=$(curl --silent --head --output /dev/null --write-out "%{http_code}" "$MAVEN_POM_URL"); then
+            echo "::error::Unable to verify Maven Central artifact for ${MAVEN_POM_URL}."
+            exit 1
+          fi
+
+          if [[ "$MAVEN_STATUS" == "200" ]]; then
             echo "::error::Maven Central artifact already exists: ${MAVEN_POM_URL}"
+            exit 1
+          elif [[ "$MAVEN_STATUS" != "404" ]]; then
+            echo "::error::Unable to verify Maven Central artifact. HTTP ${MAVEN_STATUS} for ${MAVEN_POM_URL}"
             exit 1
           fi
 

--- a/.github/workflows/android-sdk.yml
+++ b/.github/workflows/android-sdk.yml
@@ -54,6 +54,7 @@ jobs:
           PUBLICATION_NAME=release
           PUBLICATION_TASK_SUFFIX=Release
           MAVEN_VERSION="$BASE_MAVEN_VERSION"
+          PRERELEASE_PATTERN=OFF
 
           if [[ "$ENVIRONMENT" == "rc" ]]; then
             if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
@@ -66,6 +67,7 @@ jobs:
             PUBLICATION_NAME=rc
             PUBLICATION_TASK_SUFFIX=Rc
             MAVEN_VERSION="${BASE_MAVEN_VERSION}-rc.${RC_NUMBER}"
+            PRERELEASE_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$'
           elif [[ -n "$RC_NUMBER" ]]; then
             echo "::warning::rc_number is ignored when environment is ${ENVIRONMENT}."
           fi
@@ -81,6 +83,7 @@ jobs:
             echo "PUBLICATION_NAME=${PUBLICATION_NAME}"
             echo "PUBLICATION_TASK_SUFFIX=${PUBLICATION_TASK_SUFFIX}"
             echo "POM_FILE_NAME=vcl-${MAVEN_VERSION}.pom"
+            echo "PRERELEASE_PATTERN=${PRERELEASE_PATTERN}"
           } >> "$GITHUB_ENV"
 
           {
@@ -92,6 +95,7 @@ jobs:
             echo "publication_name=${PUBLICATION_NAME}"
             echo "publication_task_suffix=${PUBLICATION_TASK_SUFFIX}"
             echo "pom_file_name=vcl-${MAVEN_VERSION}.pom"
+            echo "prerelease_pattern=${PRERELEASE_PATTERN}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Base Maven version: ${BASE_MAVEN_VERSION}"
@@ -185,4 +189,4 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_PASSWORD }}
           JRELEASER_TAG_NAME: ${{ steps.versions.outputs.release_version }}
           JRELEASER_RELEASE_NAME: ${{ steps.versions.outputs.release_version }}
-          JRELEASER_PRERELEASE_PATTERN: ${{ github.event.inputs.environment == 'rc' && steps.versions.outputs.maven_version || 'OFF' }}
+          JRELEASER_PRERELEASE_PATTERN: ${{ steps.versions.outputs.prerelease_pattern }}

--- a/VCL/build.gradle
+++ b/VCL/build.gradle
@@ -12,8 +12,15 @@ ext {
     publishGroupId = "io.velocitycareerlabs"
 }
 
+def requestedProjectVersion = findProperty("projectVersion")?.toString()?.trim()
+def isPrerelease = providers.gradleProperty("prerelease")
+    .map { it.toBoolean() }
+    .getOrElse(false)
+
+ext.resolvedPublishVersion = requestedProjectVersion ?: publishVersion
+
 group = publishGroupId
-version = publishVersion
+version = resolvedPublishVersion
 
 android {
     namespace = publishGroupId
@@ -36,12 +43,12 @@ android {
         }
         rc {
             initWith(debug)
-            buildConfigField "String", "VERSION_NAME", "\"${defaultConfig.versionName}-rc\""
+            buildConfigField "String", "VERSION_NAME", "\"${resolvedPublishVersion}\""
             buildConfigField "int", "VERSION_CODE", "${defaultConfig.versionCode}"
         }
         release {
             initWith(debug)
-            buildConfigField "String", "VERSION_NAME", "\"${defaultConfig.versionName}\""
+            buildConfigField "String", "VERSION_NAME", "\"${resolvedPublishVersion}\""
             buildConfigField "int", "VERSION_CODE", "${defaultConfig.versionCode}"
         }
     }
@@ -66,13 +73,19 @@ android {
 
     libraryVariants.configureEach { variant ->
         variant.outputs.all {
-            if (variant.name == "release") {
-                outputFileName = "${publishArtifactId}-${publishVersion}.aar"
-            } else if (variant.name == "rc") {
-                outputFileName = "${publishArtifactId}-${publishVersion}-rc.aar"
+            if (variant.name == "release" || variant.name == "rc") {
+                outputFileName = "${publishArtifactId}-${resolvedPublishVersion}.aar"
             }
         }
     }
+}
+
+if (isPrerelease && !(resolvedPublishVersion ==~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$/)) {
+    throw new GradleException("RC builds require -PprojectVersion=<base>-rc.<positive integer>. Found: ${resolvedPublishVersion}")
+}
+
+if (!isPrerelease && requestedProjectVersion != null && !(resolvedPublishVersion ==~ /^[0-9]+\.[0-9]+\.[0-9]+$/)) {
+    throw new GradleException("Release builds require -PprojectVersion=<base semver>. Found: ${resolvedPublishVersion}")
 }
 
 apply from: 'publish.gradle'
@@ -142,21 +155,13 @@ tasks.register("verifyExpectedArtifactsExist") {
 }
 
 tasks.register("stageArtifacts", Copy) {
-    def isPrerelease = providers.gradleProperty("prerelease")
-        .map { it.toBoolean() }
-        .getOrElse(false)
-    def mavenVersion = isPrerelease ? "${publishVersion}-rc" : publishVersion
+    def mavenVersion = resolvedPublishVersion
     def mavenPath = "${publishGroupId.replace('.', '/')}/${publishArtifactId}/${mavenVersion}/"
     from("${layout.buildDirectory.get()}/outputs/aar") {
-        include("**/*.aar")
+        include("${publishArtifactId}-${mavenVersion}.aar")
     }
     from("${layout.buildDirectory.get()}/libs") {
-        include("**/*.jar")
-        if (isPrerelease) {
-            rename { fileName ->
-                fileName.replace("${publishArtifactId}-${publishVersion}-", "${publishArtifactId}-${mavenVersion}-")
-            }
-        }
+        include("${publishArtifactId}-${mavenVersion}-*.jar")
     }
     into("target/staging-deploy/${mavenPath}")
 }

--- a/VCL/build.gradle
+++ b/VCL/build.gradle
@@ -18,6 +18,13 @@ def isPrerelease = providers.gradleProperty("prerelease")
     .getOrElse(false)
 
 ext.resolvedPublishVersion = requestedProjectVersion ?: publishVersion
+def rcVersionPattern = /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$/
+def baseVersionPattern = /^[0-9]+\.[0-9]+\.[0-9]+$/
+def baseArtifactVersion = resolvedPublishVersion.replaceFirst(/-rc\.[1-9][0-9]*$/, "")
+ext.releaseArtifactVersion = baseArtifactVersion
+ext.rcArtifactVersion = isPrerelease ? resolvedPublishVersion : "${baseArtifactVersion}-rc"
+ext.releasePublicationVersion = releaseArtifactVersion
+ext.rcPublicationVersion = rcArtifactVersion
 
 group = publishGroupId
 version = resolvedPublishVersion
@@ -43,12 +50,12 @@ android {
         }
         rc {
             initWith(debug)
-            buildConfigField "String", "VERSION_NAME", "\"${resolvedPublishVersion}\""
+            buildConfigField "String", "VERSION_NAME", "\"${rcArtifactVersion}\""
             buildConfigField "int", "VERSION_CODE", "${defaultConfig.versionCode}"
         }
         release {
             initWith(debug)
-            buildConfigField "String", "VERSION_NAME", "\"${resolvedPublishVersion}\""
+            buildConfigField "String", "VERSION_NAME", "\"${releaseArtifactVersion}\""
             buildConfigField "int", "VERSION_CODE", "${defaultConfig.versionCode}"
         }
     }
@@ -73,18 +80,20 @@ android {
 
     libraryVariants.configureEach { variant ->
         variant.outputs.all {
-            if (variant.name == "release" || variant.name == "rc") {
-                outputFileName = "${publishArtifactId}-${resolvedPublishVersion}.aar"
+            if (variant.name == "release") {
+                outputFileName = "${publishArtifactId}-${releaseArtifactVersion}.aar"
+            } else if (variant.name == "rc") {
+                outputFileName = "${publishArtifactId}-${rcArtifactVersion}.aar"
             }
         }
     }
 }
 
-if (isPrerelease && !(resolvedPublishVersion ==~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$/)) {
+if (isPrerelease && !(resolvedPublishVersion ==~ rcVersionPattern)) {
     throw new GradleException("RC builds require -PprojectVersion=<base>-rc.<positive integer>. Found: ${resolvedPublishVersion}")
 }
 
-if (!isPrerelease && requestedProjectVersion != null && !(resolvedPublishVersion ==~ /^[0-9]+\.[0-9]+\.[0-9]+$/)) {
+if (!isPrerelease && requestedProjectVersion != null && !(resolvedPublishVersion ==~ baseVersionPattern)) {
     throw new GradleException("Release builds require -PprojectVersion=<base semver>. Found: ${resolvedPublishVersion}")
 }
 

--- a/VCL/publish.gradle
+++ b/VCL/publish.gradle
@@ -7,15 +7,15 @@
 //}
 
 afterEvaluate {
-    def releaseAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${publishVersion}.aar")
-    def rcAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${publishVersion}-rc.aar")
+    def releaseAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${resolvedPublishVersion}.aar")
+    def rcAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${resolvedPublishVersion}.aar")
 
     publishing {
         publications {
             create("release", MavenPublication) {
                 groupId = publishGroupId
                 artifactId = publishArtifactId
-                version = publishVersion
+                version = resolvedPublishVersion
 
                 artifact(releaseAar) { builtBy(tasks.named("assembleRelease")) }
                 artifact(tasks.named("generateSourcesJar").get()) { classifier = "sources" }
@@ -50,7 +50,7 @@ afterEvaluate {
             create("rc", MavenPublication) {
                 groupId = publishGroupId
                 artifactId = publishArtifactId
-                version = "${publishVersion}-rc"
+                version = resolvedPublishVersion
 
                 artifact(rcAar) { builtBy(tasks.named("assembleRc")) }
                 artifact(tasks.named("generateSourcesJar").get()) { classifier = "sources" }

--- a/VCL/publish.gradle
+++ b/VCL/publish.gradle
@@ -7,15 +7,15 @@
 //}
 
 afterEvaluate {
-    def releaseAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${resolvedPublishVersion}.aar")
-    def rcAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${resolvedPublishVersion}.aar")
+    def releaseAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${releaseArtifactVersion}.aar")
+    def rcAar = file("${layout.buildDirectory.get()}/outputs/aar/${publishArtifactId}-${rcArtifactVersion}.aar")
 
     publishing {
         publications {
             create("release", MavenPublication) {
                 groupId = publishGroupId
                 artifactId = publishArtifactId
-                version = resolvedPublishVersion
+                version = releasePublicationVersion
 
                 artifact(releaseAar) { builtBy(tasks.named("assembleRelease")) }
                 artifact(tasks.named("generateSourcesJar").get()) { classifier = "sources" }
@@ -50,7 +50,7 @@ afterEvaluate {
             create("rc", MavenPublication) {
                 groupId = publishGroupId
                 artifactId = publishArtifactId
-                version = resolvedPublishVersion
+                version = rcPublicationVersion
 
                 artifact(rcAar) { builtBy(tasks.named("assembleRc")) }
                 artifact(tasks.named("generateSourcesJar").get()) { classifier = "sources" }


### PR DESCRIPTION
## Summary
- add an `rc_number` workflow input and validate it for RC publishes
- compute Android SDK RC versions as `2.10.0-rc.N` with GitHub tags/releases as `v2.10.0-rc.N`
- pass the computed Maven version through Gradle artifacts, staging, and POM generation
- add collision checks for Maven Central artifacts, Git tags, and GitHub releases before publishing

## Verification
- `actionlint .github/workflows/android-sdk.yml`
- `./gradlew clean :VCL:assembleAllRc -PprojectVersion=2.10.0-rc.1 -Pprerelease=true --stacktrace`
- `./gradlew :VCL:stageArtifacts -PprojectVersion=2.10.0-rc.1 -Pprerelease=true`
- `./gradlew :VCL:generatePomFileForRcPublication -PprojectVersion=2.10.0-rc.1 -Pprerelease=true`
- `./gradlew :VCL:generatePomFileForRcPublication -PprojectVersion=2.10.0-rc -Pprerelease=true` fails as expected
- `./gradlew clean :VCL:assembleAllRelease -PprojectVersion=2.10.0 -Pprerelease=false --stacktrace`
- `./gradlew :VCL:stageArtifacts -PprojectVersion=2.10.0 -Pprerelease=false`
- `./gradlew :VCL:generatePomFileForReleasePublication -PprojectVersion=2.10.0 -Pprerelease=false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release and release-candidate versioning with dynamic version computation, validation, and consistent artifact naming.
  * Improved release collision detection to prevent duplicate versions by checking Maven artifacts, Git tags, and published releases.
  * Streamlined build, staging, and publication flows so the correct release/RC versions are used throughout.
  * Refined Gradle and publishing configuration to derive release vs RC outputs from computed build metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->